### PR TITLE
feat: add dark mode support

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,10 +5,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Beads Performance Dashboard</title>
     <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+      }
+    </script>
     <style>
       body {
         background-color: #f8fafc;
         font-family: ui-sans-serif, system-ui, sans-serif;
+      }
+      .dark body {
+        background-color: #0f172a;
       }
       .card {
         background: white;
@@ -16,6 +24,11 @@
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
         padding: 1.25rem;
         border: 1px solid #e2e8f0;
+      }
+      .dark .card {
+        background: #1e293b;
+        border-color: #334155;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
       }
     </style>
   </head>

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 import { io } from 'socket.io-client';
-import { Plus } from 'lucide-react';
+import { Plus, Sun, Moon } from 'lucide-react';
 import type { Issue, TimeGranularity, CreateIssueRequest } from '@shared/types';
 import { useMetrics } from '@/hooks/useMetrics';
+import { useTheme } from '@/hooks/useTheme';
 import DashboardView from '@/components/DashboardView';
 import TableView from '@/components/TableView';
 import { AgingAlertBadge } from '@/components/AgingAlertBadge';
@@ -28,6 +29,7 @@ function App() {
   const [showConfigModal, setShowConfigModal] = useState(false);
   const [showCreationModal, setShowCreationModal] = useState(false);
 
+  const { isDark, toggle: toggleTheme } = useTheme();
   const metrics = useMetrics(parsedIssues, granularity);
 
   const fetchData = async () => {
@@ -109,20 +111,27 @@ function App() {
       <header className="mb-8">
         <div className="flex justify-between items-center mb-6">
           <div>
-            <h1 className="text-2xl font-bold text-slate-900">
+            <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
               {projectName && (
-                <span className="text-slate-500 font-normal">{projectName} / </span>
+                <span className="text-slate-500 dark:text-slate-400 font-normal">{projectName} / </span>
               )}
               Beads Performance Dashboard
             </h1>
-            <p className="text-slate-500 text-sm">
+            <p className="text-slate-500 dark:text-slate-400 text-sm">
               Live View • {activeIssuesCount} issues loaded
             </p>
           </div>
           <div className="flex items-center gap-4">
-            <div className="text-xs text-slate-400">
+            <div className="text-xs text-slate-400 dark:text-slate-500">
               {loading ? 'Connecting...' : 'Connected'}
             </div>
+            <button
+              onClick={toggleTheme}
+              className="p-2 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors"
+              title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              {isDark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+            </button>
             <button
               onClick={() => setShowCreationModal(true)}
               className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700 transition-colors"
@@ -139,12 +148,12 @@ function App() {
         </div>
 
         {/* Tabs */}
-        <div className="flex space-x-4 border-b border-slate-200">
+        <div className="flex space-x-4 border-b border-slate-200 dark:border-slate-700">
           <button
             className={`pb-2 px-1 text-sm font-medium flex items-center gap-1 ${
               activeTab === 'table'
-                ? 'border-b-2 border-blue-500 text-blue-600'
-                : 'text-slate-500 hover:text-slate-700'
+                ? 'border-b-2 border-blue-500 text-blue-600 dark:text-blue-400'
+                : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
             }`}
             onClick={() => setActiveTab('table')}
           >
@@ -153,8 +162,8 @@ function App() {
           <button
             className={`pb-2 px-1 text-sm font-medium flex items-center gap-1 ${
               activeTab === 'board'
-                ? 'border-b-2 border-blue-500 text-blue-600'
-                : 'text-slate-500 hover:text-slate-700'
+                ? 'border-b-2 border-blue-500 text-blue-600 dark:text-blue-400'
+                : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
             }`}
             onClick={() => setActiveTab('board')}
           >
@@ -163,8 +172,8 @@ function App() {
           <button
             className={`pb-2 px-1 text-sm font-medium ${
               activeTab === 'dashboard'
-                ? 'border-b-2 border-blue-500 text-blue-600'
-                : 'text-slate-500 hover:text-slate-700'
+                ? 'border-b-2 border-blue-500 text-blue-600 dark:text-blue-400'
+                : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
             }`}
             onClick={() => setActiveTab('dashboard')}
           >
@@ -173,8 +182,8 @@ function App() {
           <button
             className={`pb-2 px-1 text-sm font-medium flex items-center gap-1 ${
               activeTab === 'aging'
-                ? 'border-b-2 border-blue-500 text-blue-600'
-                : 'text-slate-500 hover:text-slate-700'
+                ? 'border-b-2 border-blue-500 text-blue-600 dark:text-blue-400'
+                : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
             }`}
             onClick={() => setActiveTab('aging')}
           >
@@ -184,11 +193,11 @@ function App() {
       </header>
 
       {loading && !parsedIssues.length ? (
-        <div className="card py-20 text-center text-slate-400">Loading data...</div>
+        <div className="card py-20 text-center text-slate-400 dark:text-slate-500">Loading data...</div>
       ) : error ? (
-        <div className="card py-20 text-center text-red-500">{error}</div>
+        <div className="card py-20 text-center text-red-500 dark:text-red-400">{error}</div>
       ) : !metrics ? (
-        <div className="card border-dashed border-2 py-20 text-center text-slate-400">
+        <div className="card border-dashed border-2 border-slate-300 dark:border-slate-600 py-20 text-center text-slate-400 dark:text-slate-500">
           No issues found in .beads directory.
         </div>
       ) : activeTab === 'table' ? (

--- a/src/client/components/AgingAlertBadge.tsx
+++ b/src/client/components/AgingAlertBadge.tsx
@@ -83,9 +83,9 @@ export function AgingAlertBadge({ issues, onConfigureClick, thresholdConfig }: A
       </button>
 
       {showDropdown && (
-        <div className="absolute right-0 mt-2 w-80 bg-white border border-slate-200 rounded-lg shadow-xl z-50">
-          <div className="p-3 border-b border-slate-100 flex justify-between items-center">
-            <h3 className="text-sm font-bold text-slate-800">Aging Work Items</h3>
+        <div className="absolute right-0 mt-2 w-80 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg shadow-xl z-50">
+          <div className="p-3 border-b border-slate-100 dark:border-slate-700 flex justify-between items-center">
+            <h3 className="text-sm font-bold text-slate-800 dark:text-slate-100">Aging Work Items</h3>
             <div className="flex items-center gap-2">
               <button
                 onClick={(e) => {
@@ -93,7 +93,7 @@ export function AgingAlertBadge({ issues, onConfigureClick, thresholdConfig }: A
                   onConfigureClick();
                   setShowDropdown(false);
                 }}
-                className="text-slate-400 hover:text-slate-600 p-1"
+                className="text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 p-1"
                 title="Configure thresholds"
               >
                 <Settings className="w-4 h-4" />
@@ -103,7 +103,7 @@ export function AgingAlertBadge({ issues, onConfigureClick, thresholdConfig }: A
                   e.stopPropagation();
                   setShowDropdown(false);
                 }}
-                className="text-slate-400 hover:text-slate-600 p-1"
+                className="text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 p-1"
                 title="Close"
               >
                 <X className="w-4 h-4" />
@@ -112,41 +112,41 @@ export function AgingAlertBadge({ issues, onConfigureClick, thresholdConfig }: A
           </div>
 
           {agingIssues.length === 0 ? (
-            <div className="p-4 text-center text-slate-400 text-sm">
+            <div className="p-4 text-center text-slate-400 dark:text-slate-500 text-sm">
               No aging items found
             </div>
           ) : (
             <div className="max-h-96 overflow-y-auto">
               <table className="w-full text-sm">
-                <thead className="bg-slate-50 text-slate-600 font-medium sticky top-0">
+                <thead className="bg-slate-50 dark:bg-slate-700 text-slate-600 dark:text-slate-300 font-medium sticky top-0">
                   <tr>
                     <th className="px-3 py-2 text-left">Issue</th>
                     <th className="px-3 py-2 text-left">Age</th>
                     <th className="px-3 py-2 text-left">Status</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-slate-100">
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
                   {agingIssues.slice(0, AGING_ALERT_PREVIEW_LIMIT).map(({ issue, ageDisplay, status }) => {
                     const shortId = extractShortId(issue.id);
 
                     return (
-                      <tr key={issue.id} className="hover:bg-slate-50">
+                      <tr key={issue.id} className="hover:bg-slate-50 dark:hover:bg-slate-700">
                         <td className="px-3 py-2">
                           <div className="flex items-center gap-2">
-                            <span className="font-mono text-slate-500 text-xs">{shortId}</span>
-                            <span className="font-medium text-slate-900 truncate max-w-[120px]">
+                            <span className="font-mono text-slate-500 dark:text-slate-400 text-xs">{shortId}</span>
+                            <span className="font-medium text-slate-900 dark:text-slate-100 truncate max-w-[120px]">
                               {issue.title || 'Untitled'}
                             </span>
                           </div>
                         </td>
-                        <td className={`px-3 py-2 font-medium ${status === 'critical' ? 'text-red-600' : 'text-yellow-600'}`}>
+                        <td className={`px-3 py-2 font-medium ${status === 'critical' ? 'text-red-600 dark:text-red-400' : 'text-yellow-600 dark:text-yellow-400'}`}>
                           {ageDisplay}
                         </td>
                         <td className="px-3 py-2">
                           <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
                             status === 'critical'
-                              ? 'bg-red-100 text-red-800'
-                              : 'bg-yellow-100 text-yellow-800'
+                              ? 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300'
+                              : 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
                           }`}>
                             {status === 'critical' ? 'Critical' : 'Warning'}
                           </span>
@@ -158,7 +158,7 @@ export function AgingAlertBadge({ issues, onConfigureClick, thresholdConfig }: A
               </table>
 
               {agingIssues.length > 10 && (
-                <div className="p-2 text-center text-xs text-slate-500">
+                <div className="p-2 text-center text-xs text-slate-500 dark:text-slate-400">
                   Showing 10 of {agingIssues.length} aging items
                 </div>
               )}

--- a/src/client/components/AgingAlertList.tsx
+++ b/src/client/components/AgingAlertList.tsx
@@ -68,8 +68,8 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
       {/* Header with controls */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <div>
-          <h2 className="text-xl font-bold text-slate-900">Aging Work Items</h2>
-          <p className="text-slate-500 text-sm">
+          <h2 className="text-xl font-bold text-slate-900 dark:text-slate-100">Aging Work Items</h2>
+          <p className="text-slate-500 dark:text-slate-400 text-sm">
             {filteredIssues.length} of {allAgingIssues.length} items exceeding thresholds
           </p>
         </div>
@@ -77,7 +77,7 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
         <div className="flex items-center gap-2 flex-wrap">
           <button
             onClick={onConfigureClick}
-            className="px-3 py-1.5 bg-slate-100 text-slate-700 text-sm font-medium rounded-lg hover:bg-slate-200 transition-colors flex items-center gap-1.5"
+            className="px-3 py-1.5 bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 text-sm font-medium rounded-lg hover:bg-slate-200 dark:hover:bg-slate-600 transition-colors flex items-center gap-1.5"
           >
             <Settings className="w-4 h-4" />
             Configure Thresholds
@@ -88,8 +88,8 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
               onClick={() => setShowFilters(!showFilters)}
               className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors flex items-center gap-1.5 ${
                 hasFilters
-                  ? 'bg-blue-100 text-blue-700 hover:bg-blue-200'
-                  : 'bg-white text-slate-600 hover:bg-slate-50 border border-slate-200'
+                  ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 hover:bg-blue-200 dark:hover:bg-blue-900/50'
+                  : 'bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 border border-slate-200 dark:border-slate-600'
               }`}
             >
               <Filter className="w-4 h-4" />
@@ -97,13 +97,13 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
             </button>
 
             {showFilters && (
-              <div className="absolute right-0 mt-2 w-64 bg-white border border-slate-200 rounded-lg shadow-lg z-50">
-                <div className="p-3 border-b border-slate-100 flex justify-between items-center">
-                  <h4 className="text-sm font-bold text-slate-800">Filters</h4>
+              <div className="absolute right-0 mt-2 w-64 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg shadow-lg z-50">
+                <div className="p-3 border-b border-slate-100 dark:border-slate-700 flex justify-between items-center">
+                  <h4 className="text-sm font-bold text-slate-800 dark:text-slate-100">Filters</h4>
                   {hasFilters && (
                     <button
                       onClick={clearFilters}
-                      className="text-xs text-blue-600 hover:text-blue-700"
+                      className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
                     >
                       Clear All
                     </button>
@@ -113,11 +113,11 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
                 <div className="p-3 space-y-4">
                   {/* Status Filter */}
                   <div>
-                    <label className="block text-xs font-medium text-slate-600 mb-1">Status</label>
+                    <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Status</label>
                     <select
                       value={filterStatus}
                       onChange={(e) => setFilterStatus(e.target.value as 'all' | 'warning' | 'critical')}
-                      className="w-full px-2 py-1.5 text-sm border border-slate-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                      className="w-full px-2 py-1.5 text-sm border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                     >
                       <option value="all">All Statuses</option>
                       <option value="warning">Warning Only</option>
@@ -128,11 +128,11 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
                   {/* Assignee Filter */}
                   {uniqueAssignees.length > 0 && (
                     <div>
-                      <label className="block text-xs font-medium text-slate-600 mb-1">Assignee</label>
+                      <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Assignee</label>
                       <select
                         value={filterAssignee || ''}
                         onChange={(e) => setFilterAssignee(e.target.value || null)}
-                        className="w-full px-2 py-1.5 text-sm border border-slate-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                        className="w-full px-2 py-1.5 text-sm border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                       >
                         <option value="">All Assignees</option>
                         {uniqueAssignees.map((assignee) => (
@@ -152,28 +152,28 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div className={`card ${filterStatus === 'warning' || filterStatus === 'all' ? '' : 'opacity-50'}`}>
           <div className="flex items-center gap-3">
-            <div className={`p-2 rounded-lg ${filterStatus === 'warning' ? 'bg-yellow-100' : 'bg-yellow-50'}`}>
-              <AlertTriangle className={`w-5 h-5 ${filterStatus === 'warning' ? 'text-yellow-700' : 'text-yellow-500'}`} />
+            <div className={`p-2 rounded-lg ${filterStatus === 'warning' ? 'bg-yellow-100 dark:bg-yellow-900/30' : 'bg-yellow-50 dark:bg-yellow-900/20'}`}>
+              <AlertTriangle className={`w-5 h-5 ${filterStatus === 'warning' ? 'text-yellow-700 dark:text-yellow-400' : 'text-yellow-500 dark:text-yellow-500'}`} />
             </div>
             <div>
-              <div className="text-2xl font-black text-slate-800">
+              <div className="text-2xl font-black text-slate-800 dark:text-slate-100">
                 {allAgingIssues.filter((item) => item.status === 'warning').length}
               </div>
-              <div className="text-sm font-bold text-slate-400 uppercase">Warning Items</div>
+              <div className="text-sm font-bold text-slate-400 dark:text-slate-500 uppercase">Warning Items</div>
             </div>
           </div>
         </div>
 
         <div className={`card ${filterStatus === 'critical' || filterStatus === 'all' ? '' : 'opacity-50'}`}>
           <div className="flex items-center gap-3">
-            <div className={`p-2 rounded-lg ${filterStatus === 'critical' ? 'bg-red-100' : 'bg-red-50'}`}>
-              <AlertOctagon className={`w-5 h-5 ${filterStatus === 'critical' ? 'text-red-700' : 'text-red-500'}`} />
+            <div className={`p-2 rounded-lg ${filterStatus === 'critical' ? 'bg-red-100 dark:bg-red-900/30' : 'bg-red-50 dark:bg-red-900/20'}`}>
+              <AlertOctagon className={`w-5 h-5 ${filterStatus === 'critical' ? 'text-red-700 dark:text-red-400' : 'text-red-500 dark:text-red-500'}`} />
             </div>
             <div>
-              <div className="text-2xl font-black text-slate-800">
+              <div className="text-2xl font-black text-slate-800 dark:text-slate-100">
                 {allAgingIssues.filter((item) => item.status === 'critical').length}
               </div>
-              <div className="text-sm font-bold text-slate-400 uppercase">Critical Items</div>
+              <div className="text-sm font-bold text-slate-400 dark:text-slate-500 uppercase">Critical Items</div>
             </div>
           </div>
         </div>
@@ -183,7 +183,7 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
       <div className="card overflow-hidden">
         <div className="overflow-x-auto">
           <table className="min-w-full text-sm">
-            <thead className="bg-slate-50 text-slate-600 font-medium border-b">
+            <thead className="bg-slate-50 dark:bg-slate-700 text-slate-600 dark:text-slate-300 font-medium border-b dark:border-slate-600">
               <tr>
                 <th className="px-4 py-3 text-left">Issue</th>
                 <th className="px-4 py-3 text-left">Age</th>
@@ -193,10 +193,10 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
                 <th className="px-4 py-3 text-left">Created</th>
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-100">
+            <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
               {filteredIssues.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className="px-4 py-8 text-center text-slate-400">
+                  <td colSpan={6} className="px-4 py-8 text-center text-slate-400 dark:text-slate-500">
                     No aging items found matching filters
                   </td>
                 </tr>
@@ -208,28 +208,28 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
                   return (
                     <tr
                       key={issue.id}
-                      className={`hover:bg-slate-50 transition-colors ${
+                      className={`hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors ${
                         status === 'critical'
-                          ? 'bg-red-50/50 border-l-4 border-red-300'
-                          : 'bg-yellow-50/50 border-l-4 border-yellow-300'
+                          ? 'bg-red-50/50 dark:bg-red-900/20 border-l-4 border-red-300 dark:border-red-500'
+                          : 'bg-yellow-50/50 dark:bg-yellow-900/20 border-l-4 border-yellow-300 dark:border-yellow-500'
                       }`}
                     >
                       <td className="px-4 py-3">
                         <div className="flex items-center gap-2">
-                          <span className="font-mono text-slate-500 text-xs">{shortId}</span>
-                          <span className="font-medium text-slate-900">
+                          <span className="font-mono text-slate-500 dark:text-slate-400 text-xs">{shortId}</span>
+                          <span className="font-medium text-slate-900 dark:text-slate-100">
                             {issue.title || 'Untitled'}
                           </span>
                         </div>
                       </td>
                       <td className="px-4 py-3">
                         <div className="flex items-center gap-2">
-                          <Clock className="w-4 h-4 text-slate-400" />
+                          <Clock className="w-4 h-4 text-slate-400 dark:text-slate-500" />
                           <div>
-                            <div className={`font-medium ${status === 'critical' ? 'text-red-600' : 'text-yellow-600'}`}>
+                            <div className={`font-medium ${status === 'critical' ? 'text-red-600 dark:text-red-400' : 'text-yellow-600 dark:text-yellow-400'}`}>
                               {ageDisplay}
                             </div>
-                            <div className="text-xs text-slate-400">
+                            <div className="text-xs text-slate-400 dark:text-slate-500">
                               {ageHours >= 24 ? 'Over 1 day' : 'Recent'}
                             </div>
                           </div>
@@ -238,8 +238,8 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
                       <td className="px-4 py-3">
                         <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
                           status === 'critical'
-                            ? 'bg-red-100 text-red-800'
-                            : 'bg-yellow-100 text-yellow-800'
+                            ? 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300'
+                            : 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300'
                         }`}>
                           {status === 'critical' ? 'Critical' : 'Warning'}
                         </span>
@@ -247,20 +247,20 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
                       <td className="px-4 py-3">
                         {issue.assignee ? (
                           <div className="flex items-center gap-2">
-                            <User className="w-4 h-4 text-slate-400" />
-                            <span className="text-slate-700">{issue.assignee}</span>
+                            <User className="w-4 h-4 text-slate-400 dark:text-slate-500" />
+                            <span className="text-slate-700 dark:text-slate-300">{issue.assignee}</span>
                           </div>
                         ) : (
-                          <span className="text-slate-400 text-xs">Unassigned</span>
+                          <span className="text-slate-400 dark:text-slate-500 text-xs">Unassigned</span>
                         )}
                       </td>
                       <td className="px-4 py-3">
-                        <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-blue-50 text-blue-700">
+                        <span className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300">
                           {getTypeIcon(issue.issue_type)}
                           {issue.issue_type}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-slate-500">
+                      <td className="px-4 py-3 text-slate-500 dark:text-slate-400">
                         {createdDate.toLocaleDateString()}
                       </td>
                     </tr>
@@ -272,7 +272,7 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
         </div>
 
         {filteredIssues.length > 0 && (
-          <div className="p-3 border-t border-slate-100 bg-slate-50 text-xs text-slate-500">
+          <div className="p-3 border-t border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 text-xs text-slate-500 dark:text-slate-400">
             Showing {filteredIssues.length} of {allAgingIssues.length} aging items
           </div>
         )}
@@ -280,27 +280,27 @@ export function AgingAlertList({ issues, onConfigureClick, thresholdConfig }: Ag
 
       {/* Threshold Information */}
       <div className="card">
-        <h3 className="text-sm font-bold mb-3 text-slate-700">Current Thresholds</h3>
+        <h3 className="text-sm font-bold mb-3 text-slate-700 dark:text-slate-200">Current Thresholds</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-yellow-100 rounded-lg">
-              <AlertTriangle className="w-5 h-5 text-yellow-700" />
+            <div className="p-2 bg-yellow-100 dark:bg-yellow-900/30 rounded-lg">
+              <AlertTriangle className="w-5 h-5 text-yellow-700 dark:text-yellow-400" />
             </div>
             <div>
-              <div className="text-sm font-medium text-slate-700">Warning Threshold</div>
-              <div className="text-sm text-slate-500">
+              <div className="text-sm font-medium text-slate-700 dark:text-slate-200">Warning Threshold</div>
+              <div className="text-sm text-slate-500 dark:text-slate-400">
                 {thresholdConfig.warningThreshold} {thresholdConfig.warningUnit}
               </div>
             </div>
           </div>
 
           <div className="flex items-center gap-3">
-            <div className="p-2 bg-red-100 rounded-lg">
-              <AlertOctagon className="w-5 h-5 text-red-700" />
+            <div className="p-2 bg-red-100 dark:bg-red-900/30 rounded-lg">
+              <AlertOctagon className="w-5 h-5 text-red-700 dark:text-red-400" />
             </div>
             <div>
-              <div className="text-sm font-medium text-slate-700">Critical Threshold</div>
-              <div className="text-sm text-slate-500">
+              <div className="text-sm font-medium text-slate-700 dark:text-slate-200">Critical Threshold</div>
+              <div className="text-sm text-slate-500 dark:text-slate-400">
                 {thresholdConfig.criticalThreshold} {thresholdConfig.criticalUnit}
               </div>
             </div>

--- a/src/client/components/AgingThresholdConfig.tsx
+++ b/src/client/components/AgingThresholdConfig.tsx
@@ -169,17 +169,17 @@ export function AgingThresholdConfig({ issues, onClose, onSave }: AgingThreshold
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50 animate-in fade-in duration-200">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col animate-in zoom-in-95 duration-200">
-        <div className="flex justify-between items-start p-6 border-b border-slate-100">
+      <div className="bg-white dark:bg-slate-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col animate-in zoom-in-95 duration-200">
+        <div className="flex justify-between items-start p-6 border-b border-slate-100 dark:border-slate-700">
           <div>
-            <h3 className="text-xl font-bold text-slate-900">Aging Threshold Configuration</h3>
-            <p className="text-sm text-slate-500 mt-1">
+            <h3 className="text-xl font-bold text-slate-900 dark:text-slate-100">Aging Threshold Configuration</h3>
+            <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
               Set when work items should be flagged as aging
             </p>
           </div>
           <button
             onClick={onClose}
-            className="text-slate-400 hover:text-slate-600 transition-colors p-1"
+            className="text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors p-1"
             title="Close"
           >
             <X className="w-6 h-6" />
@@ -195,13 +195,13 @@ export function AgingThresholdConfig({ issues, onClose, onSave }: AgingThreshold
                 id="autoCalculate"
                 checked={config.useAutoCalculation}
                 onChange={(e) => handleInputChange('useAutoCalculation', e.target.checked)}
-                className="mt-1 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                className="mt-1 rounded border-slate-300 dark:border-slate-600 text-blue-600 focus:ring-blue-500"
               />
               <div>
-                <label htmlFor="autoCalculate" className="text-sm font-medium text-slate-700">
+                <label htmlFor="autoCalculate" className="text-sm font-medium text-slate-700 dark:text-slate-200">
                   Auto-calculate from historical data
                 </label>
-                <p className="text-xs text-slate-500 mt-1">
+                <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
                   Automatically determine thresholds based on percentiles of historical cycle times
                 </p>
               </div>
@@ -277,17 +277,17 @@ export function AgingThresholdConfig({ issues, onClose, onSave }: AgingThreshold
           </div>
         </div>
 
-        <div className="p-4 border-t border-slate-100 bg-slate-50 rounded-b-lg flex justify-end gap-3">
+        <div className="p-4 border-t border-slate-100 dark:border-slate-700 bg-slate-50 dark:bg-slate-700 rounded-b-lg flex justify-end gap-3">
           <button
             onClick={handleReset}
-            className="px-4 py-2 bg-white border border-slate-300 text-slate-700 rounded-md text-sm font-medium hover:bg-slate-50 transition-colors"
+            className="px-4 py-2 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 rounded-md text-sm font-medium hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
             disabled={isCalculating}
           >
             Reset to Defaults
           </button>
           <button
             onClick={onClose}
-            className="px-4 py-2 bg-white border border-slate-300 text-slate-700 rounded-md text-sm font-medium hover:bg-slate-50 transition-colors"
+            className="px-4 py-2 bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 rounded-md text-sm font-medium hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
             disabled={isCalculating}
           >
             Cancel
@@ -297,7 +297,7 @@ export function AgingThresholdConfig({ issues, onClose, onSave }: AgingThreshold
             className={`px-4 py-2 text-white rounded-md text-sm font-medium transition-colors flex items-center gap-2 ${
               isChanged
                 ? 'bg-blue-600 hover:bg-blue-700'
-                : 'bg-slate-400 cursor-not-allowed'
+                : 'bg-slate-400 dark:bg-slate-600 cursor-not-allowed'
             }`}
             disabled={!isChanged || isCalculating}
           >

--- a/src/client/components/AllIssuesTable.tsx
+++ b/src/client/components/AllIssuesTable.tsx
@@ -331,16 +331,16 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
     const t = (type || '').toLowerCase();
     if (t === 'bug')
       return {
-        class: 'bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-600/20',
+        class: 'bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-600/20 dark:bg-rose-900/30 dark:text-rose-300 dark:ring-rose-500/30',
         icon: <Bug className="w-3 h-3" />,
       };
     if (t === 'feature')
       return {
-        class: 'bg-purple-50 text-purple-700 ring-1 ring-inset ring-purple-700/10',
+        class: 'bg-purple-50 text-purple-700 ring-1 ring-inset ring-purple-700/10 dark:bg-purple-900/30 dark:text-purple-300 dark:ring-purple-500/30',
         icon: <Box className="w-3 h-3" />,
       };
     return {
-      class: 'bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-700/10',
+      class: 'bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-500/30',
       icon: <ListCheck className="w-3 h-3" />,
     };
   };
@@ -397,12 +397,12 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
 
   const renderSortIndicator = (column: SortColumn) => {
     if (sortConfig.column !== column) {
-      return <ArrowUpDown className="w-3.5 h-3.5 text-slate-300" />;
+      return <ArrowUpDown className="w-3.5 h-3.5 text-slate-300 dark:text-slate-600" />;
     }
     return sortConfig.direction === 'asc' ? (
-      <ArrowUp className="w-3.5 h-3.5 text-slate-500" />
+      <ArrowUp className="w-3.5 h-3.5 text-slate-500 dark:text-slate-400" />
     ) : (
-      <ArrowDown className="w-3.5 h-3.5 text-slate-500" />
+      <ArrowDown className="w-3.5 h-3.5 text-slate-500 dark:text-slate-400" />
     );
   };
 
@@ -567,7 +567,7 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
         {content}
         {col.resizable && (
           <div
-            className="absolute right-0 top-0 bottom-0 w-2 cursor-col-resize hover:bg-blue-400 group-hover:bg-blue-200 transition-colors"
+            className="absolute right-0 top-0 bottom-0 w-2 cursor-col-resize hover:bg-blue-400 group-hover:bg-blue-200 dark:hover:bg-blue-500 dark:group-hover:bg-blue-700 transition-colors"
             onMouseDown={(e) => handleResizeStart(col.key, e)}
             title="Drag to resize column"
             style={{ marginRight: '-4px' }}
@@ -580,17 +580,17 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
   return (
     <>
       <div className="card overflow-hidden">
-        <div className="p-4 border-b border-slate-200 bg-slate-50/50">
+        <div className="p-4 border-b border-slate-200 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-800/50">
           <div className="flex items-center gap-3">
             <div className="relative flex-1">
               <input
                 type="text"
                 placeholder="Filter by ID, Title, Status, Type, or Priority..."
-                className="w-full pl-10 pr-4 py-2 border border-slate-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+                className="w-full pl-10 pr-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg text-sm bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
                 value={filterText}
                 onChange={(e) => setFilterText(e.target.value)}
               />
-              <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
+              <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400 dark:text-slate-500" />
             </div>
             <button
               onClick={() => setShowCreationModal(true)}
@@ -603,8 +603,8 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
         </div>
 
         {childFilter && (
-          <div className="px-4 py-2 border-b border-slate-200 bg-indigo-50 flex items-center justify-between">
-            <div className="text-xs text-indigo-800">
+          <div className="px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-indigo-50 dark:bg-indigo-900/30 flex items-center justify-between">
+            <div className="text-xs text-indigo-800 dark:text-indigo-300">
               Showing issues linked to <span className="font-semibold">{focusedEpic?.title || childFilter}</span>
             </div>
             <button
@@ -612,7 +612,7 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
                 setChildFilter(null);
                 onClearFocusedEpic();
               }}
-              className="text-xs text-indigo-700 hover:text-indigo-900 font-medium"
+              className="text-xs text-indigo-700 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-200 font-medium"
             >
               Clear child filter
             </button>
@@ -620,13 +620,13 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
         )}
 
         {hasActiveFilters && (
-          <div className="px-4 py-2 border-b border-slate-200 bg-blue-50/50 flex items-center justify-between">
-            <span className="text-xs text-slate-600">
+          <div className="px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-blue-50/50 dark:bg-blue-900/20 flex items-center justify-between">
+            <span className="text-xs text-slate-600 dark:text-slate-400">
               {statusFilter.length + typeFilter.length + priorityFilter.length} filter(s) active
             </span>
             <button
               onClick={clearAllFilters}
-              className="text-xs text-blue-600 hover:text-blue-700 font-medium flex items-center gap-1"
+              className="text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 font-medium flex items-center gap-1"
             >
               <FilterX className="w-3.5 h-3.5" />
               Clear All Filters
@@ -634,19 +634,19 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
           </div>
         )}
 
-        <div className="px-4 py-2 border-b border-slate-200 bg-slate-50 flex items-center justify-end relative">
+        <div className="px-4 py-2 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800 flex items-center justify-end relative">
           <button
             onClick={(e) => {
               e.stopPropagation();
               setShowColumnMenu(!showColumnMenu);
             }}
-            className="text-xs text-slate-600 hover:text-slate-800 font-medium flex items-center gap-1 px-2 py-1 rounded hover:bg-slate-100 transition-colors"
+            className="text-xs text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200 font-medium flex items-center gap-1 px-2 py-1 rounded hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
           >
             <Settings className="w-3.5 h-3.5" />
             Columns
           </button>
           {showColumnMenu && (
-            <div className="absolute right-4 top-10 z-50 bg-white border border-slate-200 rounded-lg shadow-lg min-w-48 py-1">
+            <div className="absolute right-4 top-10 z-50 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg shadow-lg min-w-48 py-1">
               {columnConfigs.map((col) => (
                 <button
                   key={col.key}
@@ -654,14 +654,14 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
                     e.stopPropagation();
                     toggleColumnVisibility(col.key);
                   }}
-                  className="w-full px-3 py-2 text-left text-sm hover:bg-slate-50 flex items-center gap-2"
+                  className="w-full px-3 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2"
                 >
                   {col.visible ? (
                     <Eye className="w-4 h-4 text-blue-500" />
                   ) : (
-                    <EyeOff className="w-4 h-4 text-slate-300" />
+                    <EyeOff className="w-4 h-4 text-slate-300 dark:text-slate-600" />
                   )}
-                  <span className={col.visible ? 'text-slate-700' : 'text-slate-400'}>
+                  <span className={col.visible ? 'text-slate-700 dark:text-slate-200' : 'text-slate-400 dark:text-slate-500'}>
                     {col.label}
                   </span>
                 </button>
@@ -672,12 +672,12 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
 
         <div className="overflow-x-auto">
           <table className="text-sm text-left" style={{ tableLayout: 'fixed', width: `${totalTableWidth}px` }}>
-            <thead className="bg-slate-50 text-slate-600 font-medium border-b">
+            <thead className="bg-slate-50 dark:bg-slate-800 text-slate-600 dark:text-slate-300 font-medium border-b dark:border-slate-700">
               <tr>
                 {visibleColumns.map(renderColumnHeader)}
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-100">
+            <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
               {sortedIssues.map((issue) => {
                 const created = new Date(issue.created_at);
                 const updated = issue.updated_at ? new Date(issue.updated_at) : null;
@@ -696,25 +696,25 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
                 const typeInfo = getTypeInfo(issue.issue_type);
 
                 return (
-                  <tr key={issue.id} className="hover:bg-slate-50 group">
-                    <td className="px-6 py-3 font-mono text-slate-500 whitespace-nowrap" style={getColumnStyle('id')}>
+                  <tr key={issue.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50 group">
+                    <td className="px-6 py-3 font-mono text-slate-500 dark:text-slate-400 whitespace-nowrap" style={getColumnStyle('id')}>
                       <div className="flex items-center gap-2">
                         <span>{shortId}</span>
                         <button
                           onClick={() => handleCopy(issue.id)}
-                          className="text-slate-300 hover:text-slate-600 transition-colors opacity-0 group-hover:opacity-100"
+                          className="text-slate-300 hover:text-slate-600 dark:text-slate-600 dark:hover:text-slate-300 transition-colors opacity-0 group-hover:opacity-100"
                           title="Copy full ID"
                         >
                           <Copy className="w-3.5 h-3.5" />
                         </button>
                       </div>
                     </td>
-                    <td className="px-6 py-3 font-medium text-slate-900" style={getColumnStyle('title')}>
+                    <td className="px-6 py-3 font-medium text-slate-900 dark:text-slate-100" style={getColumnStyle('title')}>
                       <div className="flex items-center gap-2">
                         <span>{issue.title || 'Untitled'}</span>
                         <button
                           onClick={() => openDescription(issue)}
-                          className="ml-auto text-slate-300 hover:text-blue-600 transition-colors"
+                          className="ml-auto text-slate-300 hover:text-blue-600 dark:text-slate-600 dark:hover:text-blue-400 transition-colors"
                           title="View Description"
                         >
                           <PanelTopOpen className="w-3.5 h-3.5" />
@@ -748,20 +748,20 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
                         <button
                           onClick={() => handlePriorityUpdate(issue.id, (issue.priority - 1) as Priority)}
                           disabled={issue.priority === 0 || updatingPriority === issue.id}
-                          className="text-slate-300 hover:text-blue-600 disabled:text-slate-200 disabled:cursor-not-allowed opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity p-0.5"
+                          className="text-slate-300 hover:text-blue-600 disabled:text-slate-200 disabled:cursor-not-allowed dark:text-slate-600 dark:hover:text-blue-400 dark:disabled:text-slate-700 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity p-0.5"
                           title="Increase Priority (Up Arrow)"
                           tabIndex={-1}
                         >
                           <ChevronUp className="w-3.5 h-3.5" />
                         </button>
-                        <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-white border ${issue.priority <= 1 ? 'border-red-200' : 'border-slate-200'}`}>
+                        <span className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-white dark:bg-slate-800 border ${issue.priority <= 1 ? 'border-red-200 dark:border-red-800' : 'border-slate-200 dark:border-slate-600'} dark:text-slate-200`}>
                           {PriorityIcon}
                           {priorityLabel}
                         </span>
                         <button
                           onClick={() => handlePriorityUpdate(issue.id, (issue.priority + 1) as Priority)}
                           disabled={issue.priority === 4 || updatingPriority === issue.id}
-                          className="text-slate-300 hover:text-blue-600 disabled:text-slate-200 disabled:cursor-not-allowed opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity p-0.5"
+                          className="text-slate-300 hover:text-blue-600 disabled:text-slate-200 disabled:cursor-not-allowed dark:text-slate-600 dark:hover:text-blue-400 dark:disabled:text-slate-700 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity p-0.5"
                           title="Decrease Priority (Down Arrow)"
                           tabIndex={-1}
                         >
@@ -773,25 +773,25 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
                       <span
                         className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium capitalize ${
                           issue.status === 'blocked'
-                            ? 'bg-amber-50 text-amber-800'
+                            ? 'bg-amber-50 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300'
                             : issue.status === 'closed'
-                            ? 'bg-emerald-50 text-emerald-700'
-                            : 'bg-slate-100 text-slate-700'
+                            ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'
+                            : 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300'
                         }`}
                       >
                         {issue.status.replace('_', ' ')}
                       </span>
                     </td>
-                    <td className="px-6 py-3 whitespace-nowrap text-slate-500" style={getColumnStyle('created')}>
+                    <td className="px-6 py-3 whitespace-nowrap text-slate-500 dark:text-slate-400" style={getColumnStyle('created')}>
                       {created.toLocaleDateString()}
                     </td>
-                    <td className="px-6 py-3 whitespace-nowrap text-slate-500" style={getColumnStyle('updated')}>
+                    <td className="px-6 py-3 whitespace-nowrap text-slate-500 dark:text-slate-400" style={getColumnStyle('updated')}>
                       {updated ? updated.toLocaleDateString() : '—'}
                     </td>
-                    <td className={`px-6 py-3 ${cycleTime === '-' ? 'text-slate-400' : 'text-slate-900'}`} style={getColumnStyle('cycleTime')}>
+                    <td className={`px-6 py-3 ${cycleTime === '-' ? 'text-slate-400 dark:text-slate-500' : 'text-slate-900 dark:text-slate-100'}`} style={getColumnStyle('cycleTime')}>
                       {cycleTime}
                     </td>
-                    <td className={`px-6 py-3 ${isStale ? 'text-amber-600 font-medium' : 'text-slate-900'}`} style={getColumnStyle('age')}>
+                    <td className={`px-6 py-3 ${isStale ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-slate-900 dark:text-slate-100'}`} style={getColumnStyle('age')}>
                       {age}
                     </td>
                     <td className="px-6 py-3" style={getColumnStyle('actions')}>
@@ -800,7 +800,7 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
                           <button
                             onClick={() => handleStatusUpdate(issue.id, 'in_progress')}
                             disabled={updatingStatus === issue.id}
-                            className="p-1.5 text-blue-600 hover:bg-blue-50 rounded transition-colors disabled:opacity-50"
+                            className="p-1.5 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded transition-colors disabled:opacity-50"
                             title="Resume Progress"
                           >
                             <Play className="w-4 h-4" />
@@ -810,7 +810,7 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
                           <button
                             onClick={() => handleStatusUpdate(issue.id, 'in_progress')}
                             disabled={updatingStatus === issue.id}
-                            className="p-1.5 text-blue-600 hover:bg-blue-50 rounded transition-colors disabled:opacity-50"
+                            className="p-1.5 text-blue-600 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded transition-colors disabled:opacity-50"
                             title="Start Progress"
                           >
                             <Play className="w-4 h-4" />
@@ -820,7 +820,7 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
                           <button
                             onClick={() => handleStatusUpdate(issue.id, 'closed')}
                             disabled={updatingStatus === issue.id}
-                            className="p-1.5 text-green-600 hover:bg-green-50 rounded transition-colors disabled:opacity-50"
+                            className="p-1.5 text-green-600 hover:bg-green-50 dark:hover:bg-green-900/30 rounded transition-colors disabled:opacity-50"
                             title="Close Issue"
                           >
                             <Check className="w-4 h-4" />
@@ -833,7 +833,7 @@ function AllIssuesTable({ issues, focusedEpicId, onClearFocusedEpic }: AllIssues
               })}
               {sortedIssues.length === 0 && (
                 <tr>
-                  <td colSpan={visibleColumns.length} className="px-6 py-8 text-center text-slate-400">
+                  <td colSpan={visibleColumns.length} className="px-6 py-8 text-center text-slate-400 dark:text-slate-500">
                     No issues found{filterText ? ` matching "${filterText}"` : ''}
                   </td>
                 </tr>

--- a/src/client/components/DashboardView.tsx
+++ b/src/client/components/DashboardView.tsx
@@ -46,9 +46,9 @@ function CustomTooltip({ active, payload, displayUnit }: CustomTooltipProps) {
   if (active && payload && payload.length) {
     const data = payload[0].payload;
     return (
-      <div className="bg-white p-2 border border-slate-200 shadow-md rounded text-xs">
+      <div className="bg-white dark:bg-slate-800 p-2 border border-slate-200 dark:border-slate-600 shadow-md rounded text-xs text-slate-700 dark:text-slate-200">
         <p className="font-bold">{data.title}</p>
-        <p>{data.id}</p>
+        <p className="text-slate-500 dark:text-slate-400">{data.id}</p>
         {data.cycleTimeHours !== undefined && (
           <p>Cycle Time: {formatTimeValue(data.cycleTimeHours, displayUnit)}</p>
         )}
@@ -68,7 +68,7 @@ function DashboardView({ metrics, granularity, onGranularityChange }: DashboardV
     <div className="space-y-6">
       {/* Granularity Picker */}
       <div className="flex items-center space-x-2 text-sm">
-        <span className="text-slate-500 font-medium">Time Scale:</span>
+        <span className="text-slate-500 dark:text-slate-400 font-medium">Time Scale:</span>
         <div className="inline-flex rounded-md shadow-sm" role="group">
           {GRANULARITY_OPTIONS.map((option) => (
             <button
@@ -77,7 +77,7 @@ function DashboardView({ metrics, granularity, onGranularityChange }: DashboardV
               className={`px-3 py-1.5 text-xs font-medium border first:rounded-l-md last:rounded-r-md ${
                 granularity === option.value
                   ? 'bg-blue-600 text-white border-blue-600 z-10'
-                  : 'bg-white text-slate-600 border-slate-300 hover:bg-slate-50'
+                  : 'bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-300 border-slate-300 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-700'
               }`}
             >
               {option.label}
@@ -89,35 +89,35 @@ function DashboardView({ metrics, granularity, onGranularityChange }: DashboardV
       {/* Summary row */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
         <div className="card border-l-4 border-l-orange-500">
-          <div className="text-3xl font-black text-slate-800">
+          <div className="text-3xl font-black text-slate-800 dark:text-slate-100">
             {metrics.avgAge}{' '}
-            <span className="text-sm font-normal text-slate-400">{metrics.displayUnit}</span>
+            <span className="text-sm font-normal text-slate-400 dark:text-slate-500">{metrics.displayUnit}</span>
           </div>
-          <div className="text-sm font-bold text-slate-400 uppercase">
+          <div className="text-sm font-bold text-slate-400 dark:text-slate-500 uppercase">
             Avg Work Age
           </div>
         </div>
         <div className="card border-l-4 border-l-blue-500">
-          <div className="text-3xl font-black text-slate-800">
+          <div className="text-3xl font-black text-slate-800 dark:text-slate-100">
             {metrics.openCount}
           </div>
-          <div className="text-sm font-bold text-slate-400 uppercase">
+          <div className="text-sm font-bold text-slate-400 dark:text-slate-500 uppercase">
             Active WIP
           </div>
         </div>
         <div className="card border-l-4 border-l-red-500">
-          <div className="text-3xl font-black text-slate-800">
+          <div className="text-3xl font-black text-slate-800 dark:text-slate-100">
             {metrics.ageChartData[3].count}
           </div>
-          <div className="text-sm font-bold text-slate-400 uppercase">
+          <div className="text-sm font-bold text-slate-400 dark:text-slate-500 uppercase">
             Stale ({metrics.ageChartData[3].range})
           </div>
         </div>
         <div className="card border-l-4 border-l-emerald-500">
-          <div className="text-3xl font-black text-slate-800">
+          <div className="text-3xl font-black text-slate-800 dark:text-slate-100">
             {metrics.flowChartData.length}
           </div>
-          <div className="text-sm font-bold text-slate-400 uppercase">
+          <div className="text-sm font-bold text-slate-400 dark:text-slate-500 uppercase">
             {metrics.displayUnit === 'hours' ? 'Periods' : 'Days'} Tracked
           </div>
         </div>
@@ -125,7 +125,7 @@ function DashboardView({ metrics, granularity, onGranularityChange }: DashboardV
 
       {/* Lead Time Scatterplot */}
       <div className="card h-[400px]">
-        <h3 className="text-sm font-bold mb-6 text-slate-700">
+        <h3 className="text-sm font-bold mb-6 text-slate-700 dark:text-slate-200">
           Lead Time Scatterplot (Cycle Time)
         </h3>
         <ResponsiveContainer width="100%" height="90%">
@@ -183,7 +183,7 @@ function DashboardView({ metrics, granularity, onGranularityChange }: DashboardV
 
       {/* Aging WIP */}
       <div className="card h-[400px]">
-        <h3 className="text-sm font-bold mb-6 text-slate-700">
+        <h3 className="text-sm font-bold mb-6 text-slate-700 dark:text-slate-200">
           Aging Work in Progress
         </h3>
         <ResponsiveContainer width="100%" height="90%">
@@ -214,7 +214,7 @@ function DashboardView({ metrics, granularity, onGranularityChange }: DashboardV
 
       {/* CFD */}
       <div className="card h-[400px]">
-        <h3 className="text-sm font-bold mb-6 text-slate-700">
+        <h3 className="text-sm font-bold mb-6 text-slate-700 dark:text-slate-200">
           Cumulative Flow Diagram
         </h3>
         <ResponsiveContainer width="100%" height="90%">
@@ -260,7 +260,7 @@ function DashboardView({ metrics, granularity, onGranularityChange }: DashboardV
       {/* Age & Throughput Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="card h-80">
-          <h3 className="text-sm font-bold mb-4">Work Age Distribution</h3>
+          <h3 className="text-sm font-bold mb-4 text-slate-700 dark:text-slate-200">Work Age Distribution</h3>
           <ResponsiveContainer width="100%" height="90%">
             <BarChart data={metrics.ageChartData}>
               <XAxis dataKey="range" fontSize={12} />
@@ -278,7 +278,7 @@ function DashboardView({ metrics, granularity, onGranularityChange }: DashboardV
           </ResponsiveContainer>
         </div>
         <div className="card h-80">
-          <h3 className="text-sm font-bold mb-4">
+          <h3 className="text-sm font-bold mb-4 text-slate-700 dark:text-slate-200">
             {metrics.granularity === 'daily' ? 'Daily' : 'Period'} Throughput
           </h3>
           <ResponsiveContainer width="100%" height="90%">

--- a/src/client/components/EpicsTable.tsx
+++ b/src/client/components/EpicsTable.tsx
@@ -245,12 +245,12 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
 
   const renderSortIndicator = (column: EpicSortColumn) => {
     if (sortConfig.column !== column) {
-      return <ArrowUpDown className="w-3.5 h-3.5 text-slate-300" />;
+      return <ArrowUpDown className="w-3.5 h-3.5 text-slate-300 dark:text-slate-500" />;
     }
     return sortConfig.direction === 'asc' ? (
-      <ArrowUp className="w-3.5 h-3.5 text-slate-500" />
+      <ArrowUp className="w-3.5 h-3.5 text-slate-500 dark:text-slate-300" />
     ) : (
-      <ArrowDown className="w-3.5 h-3.5 text-slate-500" />
+      <ArrowDown className="w-3.5 h-3.5 text-slate-500 dark:text-slate-300" />
     );
   };
 
@@ -344,7 +344,7 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
         </div>
         {col.resizable && (
           <div
-            className="absolute top-0 right-0 w-2 h-full cursor-col-resize hover:bg-indigo-200/50 active:bg-indigo-300"
+            className="absolute top-0 right-0 w-2 h-full cursor-col-resize hover:bg-indigo-200/50 dark:hover:bg-indigo-700/50 active:bg-indigo-300 dark:active:bg-indigo-600"
             onMouseDown={(e) => handleResizeStart(col.key, e)}
             onClick={(e) => e.stopPropagation()}
           />
@@ -356,17 +356,17 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
   return (
     <>
       <div className="card overflow-hidden">
-        <div className="p-4 border-b border-slate-200 bg-slate-50/50">
+        <div className="p-4 border-b border-slate-200 dark:border-slate-600 bg-slate-50/50 dark:bg-slate-700/50">
           <div className="flex gap-3">
             <div className="relative flex-1">
               <input
                 type="text"
                 placeholder="Search epics by ID, title, or owner..."
-                className="w-full pl-10 pr-4 py-2 border border-slate-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow"
+                className="w-full pl-10 pr-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-shadow"
                 value={filterText}
                 onChange={(e) => setFilterText(e.target.value)}
               />
-              <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
+              <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400 dark:text-slate-500" />
             </div>
             <div className="relative">
               <button
@@ -374,24 +374,24 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
                   e.stopPropagation();
                   setColumnMenuOpen(!columnMenuOpen);
                 }}
-                className="px-3 py-2 border border-slate-300 rounded-lg text-sm bg-white hover:bg-slate-50 flex items-center gap-2"
+                className="px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-lg text-sm bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 flex items-center gap-2"
                 title="Show/hide columns"
               >
                 <Settings className="w-4 h-4" />
                 Columns
               </button>
               {columnMenuOpen && (
-                <div className="absolute right-0 mt-2 w-48 bg-white border border-slate-200 rounded-lg shadow-lg z-10 py-1">
+                <div className="absolute right-0 mt-2 w-48 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg shadow-lg z-10 py-1">
                   {columnConfigs.map((col) => (
                     <label
                       key={col.key}
-                      className="flex items-center gap-2 px-3 py-2 hover:bg-slate-50 cursor-pointer"
+                      className="flex items-center gap-2 px-3 py-2 hover:bg-slate-50 dark:hover:bg-slate-700 cursor-pointer text-slate-700 dark:text-slate-200"
                     >
                       <input
                         type="checkbox"
                         checked={col.visible}
                         onChange={() => toggleColumnVisibility(col.key)}
-                        className="rounded border-slate-300"
+                        className="rounded border-slate-300 dark:border-slate-600"
                       />
                       <span className="text-sm">{col.label}</span>
                     </label>
@@ -403,8 +403,8 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
         </div>
 
         {hasActiveFilters && (
-          <div className="px-4 py-2 border-b border-slate-200 bg-indigo-50/50 flex items-center justify-between">
-            <span className="text-xs text-slate-600">
+          <div className="px-4 py-2 border-b border-slate-200 dark:border-slate-600 bg-indigo-50/50 dark:bg-indigo-900/20 flex items-center justify-between">
+            <span className="text-xs text-slate-600 dark:text-slate-400">
               {statusFilter.length + priorityFilter.length} filter(s) active
             </span>
             <button
@@ -412,7 +412,7 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
                 setStatusFilter([]);
                 setPriorityFilter([]);
               }}
-              className="text-xs text-indigo-600 hover:text-indigo-800 font-medium flex items-center gap-1"
+              className="text-xs text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-medium flex items-center gap-1"
             >
               <FilterX className="w-3.5 h-3.5" />
               Clear All Filters
@@ -422,12 +422,12 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
 
         <div className="overflow-x-auto">
           <table className="text-sm text-left" style={{ tableLayout: 'fixed', width: `${totalTableWidth}px` }}>
-            <thead className="bg-slate-50 text-slate-600 font-medium border-b">
+            <thead className="bg-slate-50 dark:bg-slate-700 text-slate-600 dark:text-slate-300 font-medium border-b dark:border-slate-600">
               <tr>
                 {visibleColumns.map(renderColumnHeader)}
               </tr>
             </thead>
-            <tbody className="divide-y divide-slate-100">
+            <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
               {sortedEpics.map((epic) => {
                 const childCounts = getChildCounts(epic.id);
                 const created = new Date(epic.created_at);
@@ -436,12 +436,12 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
                 const isComplete = childCounts.total > 0 && childCounts.open === 0;
                 const isAllOpen = childCounts.total > 0 && childCounts.open === childCounts.total;
                 const childClass = childCounts.total === 0
-                  ? 'text-slate-400'
+                  ? 'text-slate-400 dark:text-slate-500'
                   : isComplete
-                  ? 'text-emerald-600'
+                  ? 'text-emerald-600 dark:text-emerald-400'
                   : isAllOpen
-                  ? 'text-amber-600'
-                  : 'text-indigo-700';
+                  ? 'text-amber-600 dark:text-amber-400'
+                  : 'text-indigo-700 dark:text-indigo-300';
                 const completion = childCounts.total === 0
                   ? 0
                   : ((childCounts.total - childCounts.open) / childCounts.total) * 100;
@@ -449,25 +449,25 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
                 return (
                   <tr
                     key={epic.id}
-                    className="group hover:bg-slate-50 cursor-pointer border-l-4 border-indigo-100/70"
+                    className="group hover:bg-slate-50 dark:hover:bg-slate-700 cursor-pointer border-l-4 border-indigo-100/70 dark:border-indigo-800/70"
                     onClick={() => openDescription(epic)}
                   >
-                    <td style={getColumnStyle('id')} className="px-6 py-3 font-mono text-slate-500 whitespace-nowrap">
+                    <td style={getColumnStyle('id')} className="px-6 py-3 font-mono text-slate-500 dark:text-slate-400 whitespace-nowrap">
                       <div className="flex items-center gap-2">
-                        <Boxes className="w-4 h-4 text-indigo-500" />
+                        <Boxes className="w-4 h-4 text-indigo-500 dark:text-indigo-400" />
                         <span>{epic.id.includes('-') ? epic.id.split('-').pop() : epic.id}</span>
                       </div>
                     </td>
-                    <td style={getColumnStyle('title')} className="px-6 py-3 font-medium text-slate-900">
+                    <td style={getColumnStyle('title')} className="px-6 py-3 font-medium text-slate-900 dark:text-slate-100">
                       <div className="flex items-center gap-2">
                         <span>{epic.title || 'Untitled epic'}</span>
-                        <span className="text-xs text-slate-400">{ageInDays}d old</span>
+                        <span className="text-xs text-slate-400 dark:text-slate-500">{ageInDays}d old</span>
                         <button
                           onClick={(e) => {
                             e.stopPropagation();
                             openDescription(epic);
                           }}
-                          className="ml-auto text-slate-300 hover:text-indigo-600 transition-colors"
+                          className="ml-auto text-slate-300 dark:text-slate-500 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors"
                           title="View Description"
                         >
                           <PanelTopOpen className="w-3.5 h-3.5" />
@@ -486,13 +486,13 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
                       >
                         <div className={`flex items-baseline gap-1 font-semibold ${childClass}`}>
                           <span>{childCounts.open}</span>
-                          <span className="text-slate-500 font-normal">/ {childCounts.total}</span>
+                          <span className="text-slate-500 dark:text-slate-400 font-normal">/ {childCounts.total}</span>
                         </div>
-                        <div className="w-full bg-slate-100 rounded-full h-1 mt-1 overflow-hidden">
+                        <div className="w-full bg-slate-100 dark:bg-slate-600 rounded-full h-1 mt-1 overflow-hidden">
                           <div
                             className={`h-full rounded-full ${
                               childCounts.total === 0
-                                ? 'bg-slate-200'
+                                ? 'bg-slate-200 dark:bg-slate-500'
                                 : isComplete
                                 ? 'bg-emerald-500'
                                 : isAllOpen
@@ -508,27 +508,27 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
                       <span
                         className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium capitalize ${
                           epic.status === 'blocked'
-                            ? 'bg-amber-50 text-amber-800'
+                            ? 'bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300'
                             : epic.status === 'closed'
-                            ? 'bg-emerald-50 text-emerald-700'
-                            : 'bg-indigo-50 text-indigo-700'
+                            ? 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300'
+                            : 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300'
                         }`}
                       >
                         {epic.status.replace('_', ' ')}
                       </span>
                     </td>
                     <td style={getColumnStyle('priority')} className="px-6 py-3">
-                      <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded border border-indigo-100 text-indigo-700">
+                      <span className="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded border border-indigo-100 dark:border-indigo-800 text-indigo-700 dark:text-indigo-300">
                         {PRIORITY_LABELS[epic.priority]}
                       </span>
                     </td>
-                    <td style={getColumnStyle('assignee')} className="px-6 py-3 text-slate-600">
+                    <td style={getColumnStyle('assignee')} className="px-6 py-3 text-slate-600 dark:text-slate-400">
                       {epic.assignee || '—'}
                     </td>
-                    <td style={getColumnStyle('created')} className="px-6 py-3 text-slate-500 whitespace-nowrap">
+                    <td style={getColumnStyle('created')} className="px-6 py-3 text-slate-500 dark:text-slate-400 whitespace-nowrap">
                       {created.toLocaleDateString()}
                     </td>
-                    <td style={getColumnStyle('updated')} className="px-6 py-3 text-slate-500 whitespace-nowrap">
+                    <td style={getColumnStyle('updated')} className="px-6 py-3 text-slate-500 dark:text-slate-400 whitespace-nowrap">
                       {updated ? updated.toLocaleDateString() : '—'}
                     </td>
                   </tr>
@@ -536,7 +536,7 @@ function EpicsTable({ issues, onSelectChildren }: EpicsTableProps) {
               })}
               {sortedEpics.length === 0 && (
                 <tr>
-                  <td colSpan={8} className="px-6 py-12 text-center text-slate-400">
+                  <td colSpan={8} className="px-6 py-12 text-center text-slate-400 dark:text-slate-500">
                     No epics found. Epics are larger initiatives containing multiple issues.
                   </td>
                 </tr>

--- a/src/client/components/ErrorBoundary.tsx
+++ b/src/client/components/ErrorBoundary.tsx
@@ -47,17 +47,17 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   render(): ReactNode {
     if (this.state.hasError) {
       return (
-        <div className="min-h-screen bg-slate-50 flex items-center justify-center p-8">
-          <div className="max-w-2xl w-full bg-white rounded-lg shadow-lg p-8">
+        <div className="min-h-screen bg-slate-50 dark:bg-slate-900 flex items-center justify-center p-8">
+          <div className="max-w-2xl w-full bg-white dark:bg-slate-800 rounded-lg shadow-lg p-8">
             <div className="flex items-center gap-4 mb-6">
-              <div className="p-3 bg-red-100 rounded-full">
-                <AlertTriangle className="w-8 h-8 text-red-600" />
+              <div className="p-3 bg-red-100 dark:bg-red-900/30 rounded-full">
+                <AlertTriangle className="w-8 h-8 text-red-600 dark:text-red-400" />
               </div>
               <div>
-                <h1 className="text-2xl font-bold text-slate-900">
+                <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">
                   Something went wrong
                 </h1>
-                <p className="text-slate-600 text-sm mt-1">
+                <p className="text-slate-600 dark:text-slate-400 text-sm mt-1">
                   The application encountered an unexpected error
                 </p>
               </div>
@@ -65,16 +65,16 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 
             {this.state.error && (
               <div className="mb-6">
-                <div className="bg-slate-50 border border-slate-200 rounded-lg p-4">
-                  <p className="font-mono text-sm text-red-600 mb-2">
+                <div className="bg-slate-50 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg p-4">
+                  <p className="font-mono text-sm text-red-600 dark:text-red-400 mb-2">
                     {this.state.error.toString()}
                   </p>
                   {this.state.errorInfo && (
                     <details className="mt-3">
-                      <summary className="cursor-pointer text-xs text-slate-600 hover:text-slate-900">
+                      <summary className="cursor-pointer text-xs text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-200">
                         View stack trace
                       </summary>
-                      <pre className="mt-2 text-xs text-slate-600 overflow-auto max-h-64 p-3 bg-white rounded border border-slate-200">
+                      <pre className="mt-2 text-xs text-slate-600 dark:text-slate-400 overflow-auto max-h-64 p-3 bg-white dark:bg-slate-800 rounded border border-slate-200 dark:border-slate-600">
                         {this.state.errorInfo.componentStack}
                       </pre>
                     </details>
@@ -92,18 +92,18 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
               </button>
               <button
                 onClick={() => window.history.back()}
-                className="px-6 py-3 bg-slate-200 text-slate-700 rounded-lg font-medium hover:bg-slate-300 transition-colors"
+                className="px-6 py-3 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-200 rounded-lg font-medium hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors"
               >
                 Go Back
               </button>
             </div>
 
-            <div className="mt-6 pt-6 border-t border-slate-200">
-              <p className="text-xs text-slate-500">
+            <div className="mt-6 pt-6 border-t border-slate-200 dark:border-slate-700">
+              <p className="text-xs text-slate-500 dark:text-slate-400">
                 If this problem persists, please report it at{' '}
                 <a
                   href="https://github.com/anthropics/beads-dashboard/issues"
-                  className="text-blue-600 hover:underline"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/src/client/components/FilterDropdown.tsx
+++ b/src/client/components/FilterDropdown.tsx
@@ -37,7 +37,7 @@ function FilterDropdown({
           setOpenDropdown(isOpen ? null : column);
         }}
         className={`ml-2 p-1 rounded transition-colors ${
-          hasFilters ? 'text-blue-600 hover:text-blue-700 bg-blue-50' : 'text-slate-400 hover:text-slate-600'
+          hasFilters ? 'text-blue-600 hover:text-blue-700 bg-blue-50 dark:bg-blue-900/30 dark:text-blue-400 dark:hover:text-blue-300' : 'text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300'
         }`}
         title={hasFilters ? `Filtered (${activeFilters.length})` : 'Filter'}
       >
@@ -46,13 +46,13 @@ function FilterDropdown({
 
       {isOpen && (
         <div
-          className="absolute left-0 mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-50 min-w-[160px]"
+          className="absolute left-0 mt-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg shadow-lg z-50 min-w-[160px]"
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="p-2 border-b border-slate-100 flex justify-between items-center">
-            <span className="text-xs font-medium text-slate-600 uppercase">Filter</span>
+          <div className="p-2 border-b border-slate-100 dark:border-slate-700 flex justify-between items-center">
+            <span className="text-xs font-medium text-slate-600 dark:text-slate-400 uppercase">Filter</span>
             {hasFilters && (
-              <button onClick={onClear} className="text-xs text-blue-600 hover:text-blue-700">
+              <button onClick={onClear} className="text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300">
                 Clear
               </button>
             )}
@@ -63,15 +63,15 @@ function FilterDropdown({
               return (
                 <label
                   key={value}
-                  className="flex items-center px-3 py-2 hover:bg-slate-50 cursor-pointer text-sm"
+                  className="flex items-center px-3 py-2 hover:bg-slate-50 dark:hover:bg-slate-700 cursor-pointer text-sm"
                 >
                   <input
                     type="checkbox"
                     checked={isSelected}
                     onChange={() => onToggle(value)}
-                    className="mr-2 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                    className="mr-2 rounded border-slate-300 dark:border-slate-600 text-blue-600 focus:ring-blue-500 dark:bg-slate-700"
                   />
-                  <span className={`capitalize ${isSelected ? 'font-medium text-slate-900' : 'text-slate-700'}`}>
+                  <span className={`capitalize ${isSelected ? 'font-medium text-slate-900 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'}`}>
                     {displayValue(value)}
                   </span>
                 </label>

--- a/src/client/components/IssueCreationModal.tsx
+++ b/src/client/components/IssueCreationModal.tsx
@@ -3,6 +3,7 @@ import { X } from 'lucide-react';
 import MDEditor from '@uiw/react-md-editor';
 import type { IssueType, Priority, CreateIssueRequest } from '@shared/types';
 import { PRIORITY_LABELS } from '@shared/types';
+import { useTheme } from '@/hooks/useTheme';
 
 interface IssueCreationModalProps {
   onClose: () => void;
@@ -10,6 +11,7 @@ interface IssueCreationModalProps {
 }
 
 function IssueCreationModal({ onClose, onSubmit }: IssueCreationModalProps) {
+  const { isDark } = useTheme();
   const [title, setTitle] = useState('');
   const [type, setType] = useState<IssueType>('task');
   const [priority, setPriority] = useState<Priority>(2); // Default to Medium
@@ -110,13 +112,13 @@ function IssueCreationModal({ onClose, onSubmit }: IssueCreationModalProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 animate-in fade-in duration-200">
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col animate-in zoom-in-95 duration-200">
-        <div className="flex justify-between items-start p-6 border-b border-slate-100">
+      <div className="bg-white dark:bg-slate-900 rounded-lg shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col animate-in zoom-in-95 duration-200">
+        <div className="flex justify-between items-start p-6 border-b border-slate-100 dark:border-slate-800">
           <div>
-            <h3 className="text-xl font-bold text-slate-900">Create New Issue</h3>
-            <p className="text-sm text-slate-500 mt-1">Fill in the details to create a new issue</p>
+            <h3 className="text-xl font-bold text-slate-900 dark:text-slate-100">Create New Issue</h3>
+            <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">Fill in the details to create a new issue</p>
           </div>
-          <button onClick={onClose} className="text-slate-400 hover:text-slate-600 transition-colors p-1" disabled={isSubmitting}>
+          <button onClick={onClose} className="text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors p-1" disabled={isSubmitting}>
             <X className="w-6 h-6" />
           </button>
         </div>
@@ -125,7 +127,7 @@ function IssueCreationModal({ onClose, onSubmit }: IssueCreationModalProps) {
           <div className="p-6 overflow-y-auto flex-1 space-y-4">
             {/* Title field */}
             <div>
-              <label htmlFor="issue-title" className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="issue-title" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                 Title <span className="text-red-500">*</span>
               </label>
               <input
@@ -136,18 +138,18 @@ function IssueCreationModal({ onClose, onSubmit }: IssueCreationModalProps) {
                   setTitle(e.target.value);
                   if (titleError) setTitleError(null);
                 }}
-                className={`w-full px-3 py-2 border rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:outline-none ${
-                  titleError ? 'border-red-500' : 'border-slate-300'
+                className={`w-full px-3 py-2 border rounded-md text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:outline-none ${
+                  titleError ? 'border-red-500' : 'border-slate-300 dark:border-slate-600'
                 }`}
                 placeholder="Enter issue title..."
                 disabled={isSubmitting}
               />
-              {titleError && <p className="text-red-500 text-xs mt-1">{titleError}</p>}
+              {titleError && <p className="text-red-500 dark:text-red-400 text-xs mt-1">{titleError}</p>}
             </div>
 
             {/* Type field */}
             <div>
-              <label htmlFor="issue-type" className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="issue-type" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                 Type <span className="text-red-500">*</span>
               </label>
               <select
@@ -157,8 +159,8 @@ function IssueCreationModal({ onClose, onSubmit }: IssueCreationModalProps) {
                   setType(e.target.value as IssueType);
                   if (typeError) setTypeError(null);
                 }}
-                className={`w-full px-3 py-2 border rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:outline-none ${
-                  typeError ? 'border-red-500' : 'border-slate-300'
+                className={`w-full px-3 py-2 border rounded-md text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:outline-none ${
+                  typeError ? 'border-red-500' : 'border-slate-300 dark:border-slate-600'
                 }`}
                 disabled={isSubmitting}
               >
@@ -167,19 +169,19 @@ function IssueCreationModal({ onClose, onSubmit }: IssueCreationModalProps) {
                 <option value="feature">Feature</option>
                 <option value="epic">Epic</option>
               </select>
-              {typeError && <p className="text-red-500 text-xs mt-1">{typeError}</p>}
+              {typeError && <p className="text-red-500 dark:text-red-400 text-xs mt-1">{typeError}</p>}
             </div>
 
             {/* Priority field */}
             <div>
-              <label htmlFor="issue-priority" className="block text-sm font-medium text-slate-700 mb-1">
+              <label htmlFor="issue-priority" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
                 Priority
               </label>
               <select
                 id="issue-priority"
                 value={priority}
                 onChange={(e) => setPriority(parseInt(e.target.value) as Priority)}
-                className="w-full px-3 py-2 border border-slate-300 rounded-md text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:outline-none"
+                className="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-md text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:outline-none"
                 disabled={isSubmitting}
               >
                 <option value="0">{PRIORITY_LABELS[0]} (P0)</option>
@@ -192,10 +194,10 @@ function IssueCreationModal({ onClose, onSubmit }: IssueCreationModalProps) {
 
             {/* Description field */}
             <div>
-              <label htmlFor="issue-description" className="block text-sm font-medium text-slate-700 mb-2">
-                Description <span className="text-slate-400 text-xs">(optional, supports Markdown)</span>
+              <label htmlFor="issue-description" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                Description <span className="text-slate-400 dark:text-slate-500 text-xs">(optional, supports Markdown)</span>
               </label>
-              <div data-color-mode="light">
+              <div data-color-mode={isDark ? 'dark' : 'light'}>
                 <MDEditor
                   value={description}
                   onChange={(val) => setDescription(val || '')}
@@ -209,10 +211,10 @@ function IssueCreationModal({ onClose, onSubmit }: IssueCreationModalProps) {
                 />
               </div>
               {descriptionError && (
-                <p className="text-red-500 text-xs mt-1">{descriptionError}</p>
+                <p className="text-red-500 dark:text-red-400 text-xs mt-1">{descriptionError}</p>
               )}
               {description && !descriptionError && (
-                <p className="text-slate-500 text-xs mt-1">
+                <p className="text-slate-500 dark:text-slate-400 text-xs mt-1">
                   {Math.round(new Blob([description]).size / 1024)}KB / 100KB
                 </p>
               )}
@@ -220,20 +222,20 @@ function IssueCreationModal({ onClose, onSubmit }: IssueCreationModalProps) {
 
             {/* Success message */}
             {successMessage && (
-              <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded-md text-sm">
+              <div className="bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 text-green-700 dark:text-green-300 px-4 py-3 rounded-md text-sm">
                 {successMessage}
               </div>
             )}
 
             {/* Error message */}
             {error && (
-              <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-md text-sm">
+              <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 px-4 py-3 rounded-md text-sm">
                 {error}
               </div>
             )}
           </div>
 
-          <div className="p-4 border-t border-slate-100 bg-slate-50 rounded-b-lg">
+          <div className="p-4 border-t border-slate-100 dark:border-slate-800 bg-slate-50 dark:bg-slate-800 rounded-b-lg">
             {/* Create Another checkbox */}
             <div className="mb-3 flex items-center">
               <input
@@ -241,10 +243,10 @@ function IssueCreationModal({ onClose, onSubmit }: IssueCreationModalProps) {
                 type="checkbox"
                 checked={createAnother}
                 onChange={(e) => setCreateAnother(e.target.checked)}
-                className="w-4 h-4 text-blue-600 border-slate-300 rounded focus:ring-2 focus:ring-blue-500"
+                className="w-4 h-4 text-blue-600 border-slate-300 dark:border-slate-600 rounded focus:ring-2 focus:ring-blue-500 dark:bg-slate-700"
                 disabled={isSubmitting}
               />
-              <label htmlFor="create-another" className="ml-2 text-sm text-slate-700">
+              <label htmlFor="create-another" className="ml-2 text-sm text-slate-700 dark:text-slate-300">
                 Create another issue after this one
               </label>
             </div>
@@ -253,7 +255,7 @@ function IssueCreationModal({ onClose, onSubmit }: IssueCreationModalProps) {
               <button
                 type="button"
                 onClick={onClose}
-                className="px-4 py-2 bg-white border border-slate-300 text-slate-700 rounded-md text-sm font-medium hover:bg-slate-50 transition-colors"
+                className="px-4 py-2 bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 rounded-md text-sm font-medium hover:bg-slate-50 dark:hover:bg-slate-600 transition-colors"
                 disabled={isSubmitting}
               >
                 Cancel

--- a/src/client/components/IssueViewModal.tsx
+++ b/src/client/components/IssueViewModal.tsx
@@ -153,19 +153,19 @@ export default function IssueViewModal({ issue, onClose, onUpdate }: IssueViewMo
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 animate-in fade-in duration-200" onClick={handleClose}>
-      <div 
-        className="bg-white rounded-lg shadow-xl w-full max-w-3xl max-h-[85vh] flex flex-col animate-in zoom-in-95 duration-200"
+      <div
+        className="bg-white dark:bg-slate-900 rounded-lg shadow-xl w-full max-w-3xl max-h-[85vh] flex flex-col animate-in zoom-in-95 duration-200"
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex justify-between items-start p-6 pb-2 border-b border-slate-100">
+        <div className="flex justify-between items-start p-6 pb-2 border-b border-slate-100 dark:border-slate-800">
           <div>
-            <h3 className="text-xl font-bold text-slate-900">{issue.title}</h3>
-            <p className="text-sm text-slate-500 font-mono mt-1">{issue.id}</p>
+            <h3 className="text-xl font-bold text-slate-900 dark:text-slate-100">{issue.title}</h3>
+            <p className="text-sm text-slate-500 dark:text-slate-400 font-mono mt-1">{issue.id}</p>
           </div>
           <button
             onClick={handleClose}
-            className="text-slate-400 hover:text-slate-600 transition-colors p-1"
+            className="text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors p-1"
             aria-label="Close modal"
           >
             <X className="w-6 h-6" />
@@ -173,13 +173,13 @@ export default function IssueViewModal({ issue, onClose, onUpdate }: IssueViewMo
         </div>
 
         {/* Tabs */}
-        <div className="flex items-center px-6 border-b border-slate-200 bg-slate-50/50">
+        <div className="flex items-center px-6 border-b border-slate-200 dark:border-slate-700 bg-slate-50/50 dark:bg-slate-800/50">
           <button
             onClick={() => handleTabChange('description')}
             className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors flex items-center gap-2 ${
               activeTab === 'description'
-                ? 'border-blue-500 text-blue-600'
-                : 'border-transparent text-slate-600 hover:text-slate-900 hover:border-slate-300'
+                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                : 'border-transparent text-slate-600 hover:text-slate-900 hover:border-slate-300 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:border-slate-500'
             }`}
           >
             <FileText className="w-4 h-4" />
@@ -189,8 +189,8 @@ export default function IssueViewModal({ issue, onClose, onUpdate }: IssueViewMo
             onClick={() => handleTabChange('design')}
             className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors flex items-center gap-2 ${
               activeTab === 'design'
-                ? 'border-blue-500 text-blue-600'
-                : 'border-transparent text-slate-600 hover:text-slate-900 hover:border-slate-300'
+                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                : 'border-transparent text-slate-600 hover:text-slate-900 hover:border-slate-300 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:border-slate-500'
             }`}
           >
             <Palette className="w-4 h-4" />
@@ -200,8 +200,8 @@ export default function IssueViewModal({ issue, onClose, onUpdate }: IssueViewMo
             onClick={() => handleTabChange('acceptance')}
             className={`px-4 py-3 text-sm font-medium border-b-2 transition-colors flex items-center gap-2 ${
               activeTab === 'acceptance'
-                ? 'border-blue-500 text-blue-600'
-                : 'border-transparent text-slate-600 hover:text-slate-900 hover:border-slate-300'
+                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                : 'border-transparent text-slate-600 hover:text-slate-900 hover:border-slate-300 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:border-slate-500'
             }`}
           >
             <CheckSquare className="w-4 h-4" />
@@ -213,7 +213,7 @@ export default function IssueViewModal({ issue, onClose, onUpdate }: IssueViewMo
         <div className="p-6 overflow-y-auto flex-1 min-h-[300px]">
           {isEditing ? (
             <textarea
-              className="w-full h-full min-h-[300px] p-4 border border-slate-300 rounded-lg text-sm font-mono focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:outline-none resize-none"
+              className="w-full h-full min-h-[300px] p-4 border border-slate-300 dark:border-slate-600 rounded-lg text-sm font-mono bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:ring-2 focus:ring-blue-500 focus:border-transparent focus:outline-none resize-none"
               value={editValue}
               onChange={(e) => {
                 setEditValue(e.target.value);
@@ -225,24 +225,24 @@ export default function IssueViewModal({ issue, onClose, onUpdate }: IssueViewMo
             <div className="relative group">
                <button
                   onClick={startEditing}
-                  className="absolute top-0 right-0 p-2 text-slate-400 hover:text-blue-600 bg-white/50 hover:bg-white rounded-md transition-colors opacity-0 group-hover:opacity-100"
+                  className="absolute top-0 right-0 p-2 text-slate-400 hover:text-blue-600 bg-white/50 hover:bg-white dark:bg-slate-800/50 dark:hover:bg-slate-800 dark:text-slate-500 dark:hover:text-blue-400 rounded-md transition-colors opacity-0 group-hover:opacity-100"
                   title="Edit"
                 >
                   <Edit2 className="w-4 h-4" />
                 </button>
               {getFieldValue(activeTab) ? (
                 <div
-                  className="prose prose-sm max-w-none text-slate-700"
+                  className="prose prose-sm max-w-none text-slate-700 dark:text-slate-300 dark:prose-invert"
                   dangerouslySetInnerHTML={{
                     __html: DOMPurify.sanitize(marked.parse(getFieldValue(activeTab)) as string)
                   }}
                 />
               ) : (
-                <div className="flex flex-col items-center justify-center py-12 text-slate-400">
+                <div className="flex flex-col items-center justify-center py-12 text-slate-400 dark:text-slate-500">
                   <p className="italic mb-4">No {activeTab.replace('_', ' ')} provided.</p>
-                  <button 
+                  <button
                     onClick={startEditing}
-                    className="flex items-center gap-2 px-4 py-2 bg-slate-50 hover:bg-slate-100 rounded-md text-sm font-medium transition-colors border border-slate-200"
+                    className="flex items-center gap-2 px-4 py-2 bg-slate-50 hover:bg-slate-100 dark:bg-slate-800 dark:hover:bg-slate-700 rounded-md text-sm font-medium transition-colors border border-slate-200 dark:border-slate-600 dark:text-slate-300"
                   >
                     <Edit2 className="w-3.5 h-3.5" />
                     Add Content
@@ -255,13 +255,13 @@ export default function IssueViewModal({ issue, onClose, onUpdate }: IssueViewMo
 
         {/* Footer */}
         {isEditing && (
-          <div className="p-4 border-t border-slate-100 bg-slate-50 rounded-b-lg flex justify-end gap-3">
-             <div className="flex-1 flex items-center text-xs text-amber-600 font-medium">
+          <div className="p-4 border-t border-slate-100 dark:border-slate-800 bg-slate-50 dark:bg-slate-800 rounded-b-lg flex justify-end gap-3">
+             <div className="flex-1 flex items-center text-xs text-amber-600 dark:text-amber-400 font-medium">
                 {hasUnsavedChanges && <span>● Unsaved changes</span>}
              </div>
             <button
               onClick={handleCancel}
-              className="px-4 py-2 bg-white border border-slate-300 text-slate-700 rounded-md text-sm font-medium hover:bg-slate-50 transition-colors"
+              className="px-4 py-2 bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 rounded-md text-sm font-medium hover:bg-slate-50 dark:hover:bg-slate-600 transition-colors"
               disabled={saving}
             >
               Cancel

--- a/src/client/components/KanbanBoard.tsx
+++ b/src/client/components/KanbanBoard.tsx
@@ -292,20 +292,20 @@ function KanbanBoard({ issues, onRefresh }: KanbanBoardProps) {
   return (
     <>
       {/* Search Filter */}
-      <div className="mb-4 p-4 bg-white rounded-lg border border-slate-200">
+      <div className="mb-4 p-4 bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700">
         <div className="relative">
           <input
             type="text"
             placeholder="Filter cards by title, ID, status, type, or priority..."
-            className="w-full pl-10 pr-10 py-2 border border-slate-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+            className="w-full pl-10 pr-10 py-2 border border-slate-300 dark:border-slate-600 rounded-lg text-sm bg-white dark:bg-slate-900 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
             value={filterText}
             onChange={(e) => setFilterText(e.target.value)}
           />
-          <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400" />
+          <Search className="absolute left-3 top-2.5 h-4 w-4 text-slate-400 dark:text-slate-500" />
           {filterText && (
             <button
               onClick={() => setFilterText('')}
-              className="absolute right-3 top-2.5 text-slate-400 hover:text-slate-600 transition-colors"
+              className="absolute right-3 top-2.5 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 transition-colors"
               aria-label="Clear filter"
             >
               <X className="h-4 w-4" />
@@ -313,7 +313,7 @@ function KanbanBoard({ issues, onRefresh }: KanbanBoardProps) {
           )}
         </div>
         {filterText && (
-          <div className="mt-2 text-xs text-slate-600">
+          <div className="mt-2 text-xs text-slate-600 dark:text-slate-400">
             Showing {filteredCount} of {totalIssues} cards
           </div>
         )}

--- a/src/client/components/KanbanCard.tsx
+++ b/src/client/components/KanbanCard.tsx
@@ -46,9 +46,9 @@ function KanbanCard({ issue, onClick }: KanbanCardProps) {
 
   // Age badge color based on thresholds (hour-based for agent work)
   const getAgeBadgeColor = () => {
-    if (ageInHours < 2) return 'bg-green-100 text-green-800 border-green-200';
-    if (ageInHours < 4) return 'bg-orange-100 text-orange-800 border-orange-200';
-    return 'bg-red-100 text-red-800 border-red-200';
+    if (ageInHours < 2) return 'bg-green-100 text-green-800 border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-700';
+    if (ageInHours < 4) return 'bg-orange-100 text-orange-800 border-orange-200 dark:bg-orange-900/30 dark:text-orange-300 dark:border-orange-700';
+    return 'bg-red-100 text-red-800 border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-700';
   };
 
   // Format age display
@@ -109,13 +109,13 @@ function KanbanCard({ issue, onClick }: KanbanCardProps) {
       style={style}
       {...attributes}
       {...listeners}
-      className={`bg-white rounded-lg border-l-4 ${getPriorityColor(issue.priority)} shadow-sm hover:shadow-md transition-shadow cursor-grab active:cursor-grabbing p-3 mb-2`}
+      className={`bg-white dark:bg-slate-800 rounded-lg border-l-4 ${getPriorityColor(issue.priority)} shadow-sm hover:shadow-md dark:shadow-slate-900/50 transition-shadow cursor-grab active:cursor-grabbing p-3 mb-2`}
     >
       {/* Header: ID + Priority + Info Button */}
       <div className="flex items-start justify-between mb-2">
-        <span className="text-xs font-mono text-slate-500">{shortId}</span>
+        <span className="text-xs font-mono text-slate-500 dark:text-slate-400">{shortId}</span>
         <div className="flex items-center gap-1.5">
-          <div className="flex items-center gap-1 text-slate-400">
+          <div className="flex items-center gap-1 text-slate-400 dark:text-slate-500">
             {getPriorityIcon(issue.priority)}
             {getTypeIcon(issue.issue_type)}
           </div>
@@ -124,7 +124,7 @@ function KanbanCard({ issue, onClick }: KanbanCardProps) {
               e.stopPropagation();
               onClick();
             }}
-            className="text-slate-400 hover:text-blue-600 transition-colors p-0.5 cursor-pointer"
+            className="text-slate-400 hover:text-blue-600 dark:text-slate-500 dark:hover:text-blue-400 transition-colors p-0.5 cursor-pointer"
             title="View details"
           >
             <Info className="w-3.5 h-3.5" />
@@ -133,7 +133,7 @@ function KanbanCard({ issue, onClick }: KanbanCardProps) {
       </div>
 
       {/* Title */}
-      <h4 className="text-sm font-semibold text-slate-900 mb-2 line-clamp-2">
+      <h4 className="text-sm font-semibold text-slate-900 dark:text-slate-100 mb-2 line-clamp-2">
         {issue.title || 'Untitled'}
       </h4>
 
@@ -141,16 +141,16 @@ function KanbanCard({ issue, onClick }: KanbanCardProps) {
       <div className="flex items-center justify-between text-xs">
         {/* Assignee */}
         {issue.assignee ? (
-          <div className="flex items-center gap-1 text-slate-600">
+          <div className="flex items-center gap-1 text-slate-600 dark:text-slate-400">
             {isAgent(issue.assignee) ? (
               <Bot className="w-3 h-3 text-blue-500" />
             ) : (
-              <User className="w-3 h-3 text-slate-400" />
+              <User className="w-3 h-3 text-slate-400 dark:text-slate-500" />
             )}
             <span className="truncate max-w-[100px]">{issue.assignee}</span>
           </div>
         ) : (
-          <span className="text-slate-400">Unassigned</span>
+          <span className="text-slate-400 dark:text-slate-500">Unassigned</span>
         )}
 
         {/* Age Badge */}

--- a/src/client/components/KanbanColumn.tsx
+++ b/src/client/components/KanbanColumn.tsx
@@ -69,14 +69,14 @@ function KanbanColumn({
 
   const getStatusColor = (status: IssueStatus) => {
     switch (status) {
-      case 'open': return 'bg-slate-100 text-slate-700';
-      case 'in_progress': return 'bg-blue-100 text-blue-700';
-      case 'blocked': return 'bg-red-100 text-red-700';
-      case 'closed': return 'bg-green-100 text-green-700';
-      case 'deferred': return 'bg-amber-100 text-amber-700';
-      case 'pinned': return 'bg-purple-100 text-purple-700';
-      case 'hooked': return 'bg-indigo-100 text-indigo-700';
-      default: return 'bg-slate-100 text-slate-700';
+      case 'open': return 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-200';
+      case 'in_progress': return 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300';
+      case 'blocked': return 'bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300';
+      case 'closed': return 'bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300';
+      case 'deferred': return 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300';
+      case 'pinned': return 'bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-300';
+      case 'hooked': return 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-300';
+      default: return 'bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-200';
     }
   };
 
@@ -155,14 +155,14 @@ function KanbanColumn({
                 </button>
                 {showSettings && (
                   <div
-                    className="absolute right-0 mt-2 w-48 bg-white border border-slate-200 rounded-lg shadow-lg z-50"
+                    className="absolute right-0 mt-2 w-48 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg shadow-lg z-50"
                     onClick={(e) => e.stopPropagation()}
                   >
                     <div className="p-2">
-                      <div className="text-xs font-semibold text-slate-700 mb-2">Auto-hide cards older than:</div>
+                      <div className="text-xs font-semibold text-slate-700 dark:text-slate-300 mb-2">Auto-hide cards older than:</div>
                       <button
                         onClick={() => { onAutoHideHoursChange(null); setShowSettings(false); }}
-                        className={`w-full text-left px-2 py-1 text-xs rounded hover:bg-slate-100 ${autoHideHours === null ? 'bg-blue-50 text-blue-700' : 'text-slate-700'}`}
+                        className={`w-full text-left px-2 py-1 text-xs rounded hover:bg-slate-100 dark:hover:bg-slate-700 ${autoHideHours === null ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300' : 'text-slate-700 dark:text-slate-300'}`}
                       >
                         Disabled (show all)
                       </button>
@@ -170,7 +170,7 @@ function KanbanColumn({
                         <button
                           key={hours}
                           onClick={() => { onAutoHideHoursChange(hours); setShowSettings(false); }}
-                          className={`w-full text-left px-2 py-1 text-xs rounded hover:bg-slate-100 ${autoHideHours === hours ? 'bg-blue-50 text-blue-700' : 'text-slate-700'}`}
+                          className={`w-full text-left px-2 py-1 text-xs rounded hover:bg-slate-100 dark:hover:bg-slate-700 ${autoHideHours === hours ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300' : 'text-slate-700 dark:text-slate-300'}`}
                         >
                           {formatAutoHideLabel(hours)}
                         </button>
@@ -187,13 +187,13 @@ function KanbanColumn({
       {/* Column Body */}
       <div
         ref={setNodeRef}
-        className={`flex-1 min-h-[200px] p-3 bg-slate-50 transition-colors ${
-          isOver ? 'bg-blue-50 ring-2 ring-blue-300' : ''
+        className={`flex-1 min-h-[200px] p-3 bg-slate-50 dark:bg-slate-900/50 transition-colors ${
+          isOver ? 'bg-blue-50 dark:bg-blue-900/30 ring-2 ring-blue-300 dark:ring-blue-500' : ''
         } ${hiddenCount !== undefined && hiddenCount > 0 && !showAllHidden ? '' : 'rounded-b-lg'}`}
       >
         <SortableContext items={issues.map(i => i.id)} strategy={verticalListSortingStrategy}>
           {issues.length === 0 ? (
-            <div className="flex items-center justify-center h-32 text-slate-400 text-sm">
+            <div className="flex items-center justify-center h-32 text-slate-400 dark:text-slate-500 text-sm">
               No items
             </div>
           ) : (
@@ -210,16 +210,16 @@ function KanbanColumn({
 
       {/* Footer - Show hidden count and toggle */}
       {hiddenCount !== undefined && hiddenCount > 0 && onShowAllHiddenToggle && (
-        <div className="px-4 py-2 bg-slate-100 border-t border-slate-200 rounded-b-lg">
+        <div className="px-4 py-2 bg-slate-100 dark:bg-slate-800 border-t border-slate-200 dark:border-slate-700 rounded-b-lg">
           <button
             onClick={() => onShowAllHiddenToggle(!showAllHidden)}
-            className="w-full flex items-center justify-between text-xs text-slate-600 hover:text-slate-900 transition-colors"
+            className="w-full flex items-center justify-between text-xs text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200 transition-colors"
           >
             <span className="flex items-center gap-1">
               {showAllHidden ? <EyeOff className="w-3 h-3" /> : <Eye className="w-3 h-3" />}
               {hiddenCount} card{hiddenCount !== 1 ? 's' : ''} hidden
             </span>
-            <span className="text-blue-600 font-medium">
+            <span className="text-blue-600 dark:text-blue-400 font-medium">
               {showAllHidden ? 'Hide old cards' : 'Show all'}
             </span>
           </button>

--- a/src/client/components/PercentileSelector.tsx
+++ b/src/client/components/PercentileSelector.tsx
@@ -10,14 +10,14 @@ export function PercentileSelector({ label, value, options, onChange }: Percenti
 
   return (
     <div>
-      <label htmlFor={id} className="block text-xs font-medium text-slate-600 mb-1">
+      <label htmlFor={id} className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
         {label}
       </label>
       <select
         id={id}
         value={value}
         onChange={(e) => onChange(parseFloat(e.target.value))}
-        className="w-full px-3 py-2 text-sm border border-slate-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        className="w-full px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
       >
         {options.map((option) => (
           <option key={option.value} value={option.value}>

--- a/src/client/components/QuickActions.tsx
+++ b/src/client/components/QuickActions.tsx
@@ -44,7 +44,7 @@ export default function QuickActions({ issue }: QuickActionsProps) {
         <button
           onClick={() => handleStatusUpdate('in_progress')}
           disabled={updatingStatus}
-          className="p-1.5 text-blue-600 hover:bg-blue-50 rounded transition-colors disabled:opacity-50"
+          className="p-1.5 text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 rounded transition-colors disabled:opacity-50"
           title="Start Progress"
         >
           <Play className="w-4 h-4" />
@@ -54,7 +54,7 @@ export default function QuickActions({ issue }: QuickActionsProps) {
         <button
           onClick={() => handleStatusUpdate('closed')}
           disabled={updatingStatus}
-          className="p-1.5 text-green-600 hover:bg-green-50 rounded transition-colors disabled:opacity-50"
+          className="p-1.5 text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30 rounded transition-colors disabled:opacity-50"
           title="Close Issue"
         >
           <Check className="w-4 h-4" />

--- a/src/client/components/QuickSelectButtons.tsx
+++ b/src/client/components/QuickSelectButtons.tsx
@@ -14,7 +14,7 @@ interface QuickSelectButtonsProps {
 export function QuickSelectButtons({ options, selectedValue, selectedUnit, onSelect }: QuickSelectButtonsProps) {
   return (
     <div>
-      <label className="block text-xs font-medium text-slate-600 mb-2">Quick Select</label>
+      <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-2">Quick Select</label>
       <div className="flex flex-wrap gap-2">
         {options.map((option) => (
           <button
@@ -23,7 +23,7 @@ export function QuickSelectButtons({ options, selectedValue, selectedUnit, onSel
             className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
               selectedValue === option.value && selectedUnit === option.unit
                 ? 'bg-blue-600 text-white'
-                : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                : 'bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-600'
             }`}
           >
             {option.label}

--- a/src/client/components/TableFilter.tsx
+++ b/src/client/components/TableFilter.tsx
@@ -46,8 +46,8 @@ export default function TableFilter({
         }}
         className={`ml-2 p-1 rounded transition-colors ${
           hasFilters
-            ? 'text-blue-600 hover:text-blue-700 bg-blue-50'
-            : 'text-slate-400 hover:text-slate-600'
+            ? 'text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 bg-blue-50 dark:bg-blue-900/30'
+            : 'text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300'
         }`}
         title={hasFilters ? `Filtered (${activeFilters.length})` : 'Filter'}
       >
@@ -56,15 +56,15 @@ export default function TableFilter({
 
       {isOpen && (
         <div
-          className="absolute left-0 mt-1 bg-white border border-slate-200 rounded-lg shadow-lg z-50 min-w-[160px]"
+          className="absolute left-0 mt-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg shadow-lg z-50 min-w-[160px]"
           onClick={(e) => e.stopPropagation()}
         >
-          <div className="p-2 border-b border-slate-100 flex justify-between items-center">
-            <span className="text-xs font-medium text-slate-600 uppercase">Filter</span>
+          <div className="p-2 border-b border-slate-100 dark:border-slate-700 flex justify-between items-center">
+            <span className="text-xs font-medium text-slate-600 dark:text-slate-400 uppercase">Filter</span>
             {hasFilters && (
               <button
                 onClick={() => onClear()}
-                className="text-xs text-blue-600 hover:text-blue-700"
+                className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
               >
                 Clear
               </button>
@@ -78,17 +78,17 @@ export default function TableFilter({
               return (
                 <label
                   key={value}
-                  className="flex items-center px-3 py-2 hover:bg-slate-50 cursor-pointer text-sm"
+                  className="flex items-center px-3 py-2 hover:bg-slate-50 dark:hover:bg-slate-700 cursor-pointer text-sm"
                 >
                   <input
                     type="checkbox"
                     checked={isSelected}
                     onChange={() => onToggle(value)}
-                    className="mr-2 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                    className="mr-2 rounded border-slate-300 dark:border-slate-600 text-blue-600 focus:ring-blue-500"
                   />
                   <span
                     className={`capitalize ${
-                      isSelected ? 'font-medium text-slate-900' : 'text-slate-700'
+                      isSelected ? 'font-medium text-slate-900 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'
                     }`}
                   >
                     {displayValue}

--- a/src/client/components/TableRow.tsx
+++ b/src/client/components/TableRow.tsx
@@ -74,25 +74,25 @@ export default function TableRow({
   const ageDisplay = formatAgeDisplay(ageHours);
 
   return (
-    <tr key={issue.id} className={`hover:bg-slate-50 group ${agingClass}`}>
-      <td className="px-6 py-3 font-mono text-slate-500 whitespace-nowrap">
+    <tr key={issue.id} className={`hover:bg-slate-50 dark:hover:bg-slate-700 group ${agingClass}`}>
+      <td className="px-6 py-3 font-mono text-slate-500 dark:text-slate-400 whitespace-nowrap">
         <div className="flex items-center gap-2">
           <span>{shortId}</span>
           <button
             onClick={() => onCopy(issue.id)}
-            className="text-slate-300 hover:text-slate-600 transition-colors opacity-0 group-hover:opacity-100"
+            className="text-slate-300 dark:text-slate-600 hover:text-slate-600 dark:hover:text-slate-300 transition-colors opacity-0 group-hover:opacity-100"
             title="Copy full ID"
           >
             <Copy className="w-3.5 h-3.5" />
           </button>
         </div>
       </td>
-      <td className="px-6 py-3 font-medium text-slate-900">
+      <td className="px-6 py-3 font-medium text-slate-900 dark:text-slate-100">
         <div className="flex items-center gap-2">
           <span>{issue.title || 'Untitled'}</span>
           <button
             onClick={() => onOpenDescription(issue)}
-            className="ml-auto text-slate-300 hover:text-blue-600 transition-colors"
+            className="ml-auto text-slate-300 dark:text-slate-600 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
             title="View Description"
           >
             <PanelTopOpen className="w-3.5 h-3.5" />
@@ -126,7 +126,7 @@ export default function TableRow({
           <button
             onClick={() => onPriorityUpdate(issue.id, (issue.priority - 1) as Priority)}
             disabled={issue.priority === 0 || updatingPriority === issue.id}
-            className="text-slate-300 hover:text-blue-600 disabled:text-slate-200 disabled:cursor-not-allowed opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity p-0.5"
+            className="text-slate-300 dark:text-slate-600 hover:text-blue-600 dark:hover:text-blue-400 disabled:text-slate-200 dark:disabled:text-slate-700 disabled:cursor-not-allowed opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity p-0.5"
             title="Increase Priority (Up Arrow)"
             tabIndex={-1}
           >
@@ -139,7 +139,7 @@ export default function TableRow({
           <button
             onClick={() => onPriorityUpdate(issue.id, (issue.priority + 1) as Priority)}
             disabled={issue.priority === 4 || updatingPriority === issue.id}
-            className="text-slate-300 hover:text-blue-600 disabled:text-slate-200 disabled:cursor-not-allowed opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity p-0.5"
+            className="text-slate-300 dark:text-slate-600 hover:text-blue-600 dark:hover:text-blue-400 disabled:text-slate-200 dark:disabled:text-slate-700 disabled:cursor-not-allowed opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity p-0.5"
             title="Decrease Priority (Down Arrow)"
             tabIndex={-1}
           >
@@ -152,27 +152,27 @@ export default function TableRow({
           className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
             ${
               issue.status === 'closed'
-                ? 'bg-green-100 text-green-800'
+                ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300'
                 : issue.status === 'in_progress'
-                ? 'bg-blue-100 text-blue-800'
+                ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300'
                 : issue.status === 'blocked'
-                ? 'bg-red-100 text-red-800'
+                ? 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300'
                 : issue.status === 'deferred'
-                ? 'bg-amber-100 text-amber-800'
+                ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-300'
                 : issue.status === 'pinned'
-                ? 'bg-purple-100 text-purple-800'
+                ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-800 dark:text-purple-300'
                 : issue.status === 'hooked'
-                ? 'bg-indigo-100 text-indigo-800'
-                : 'bg-slate-100 text-slate-800'
+                ? 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-800 dark:text-indigo-300'
+                : 'bg-slate-100 dark:bg-slate-700 text-slate-800 dark:text-slate-200'
             }`}
         >
           {issue.status}
         </span>
       </td>
-      <td className="px-6 py-3 text-slate-500">{created.toLocaleDateString()}</td>
-      <td className="px-6 py-3 text-slate-500">{updated ? updated.toLocaleDateString() : '-'}</td>
-      <td className="px-6 py-3 text-slate-500">{cycleTime}</td>
-      <td className={`px-6 py-3 ${agingStatus === 'critical' ? 'text-red-600 font-bold' : agingStatus === 'warning' ? 'text-yellow-600 font-medium' : 'text-slate-500'}`}>
+      <td className="px-6 py-3 text-slate-500 dark:text-slate-400">{created.toLocaleDateString()}</td>
+      <td className="px-6 py-3 text-slate-500 dark:text-slate-400">{updated ? updated.toLocaleDateString() : '-'}</td>
+      <td className="px-6 py-3 text-slate-500 dark:text-slate-400">{cycleTime}</td>
+      <td className={`px-6 py-3 ${agingStatus === 'critical' ? 'text-red-600 dark:text-red-400 font-bold' : agingStatus === 'warning' ? 'text-yellow-600 dark:text-yellow-400 font-medium' : 'text-slate-500 dark:text-slate-400'}`}>
         {agingStatus === 'normal' ? age : (
           <div className="flex items-center gap-1">
             {agingStatus === 'critical' ? (
@@ -207,21 +207,21 @@ function getTypeInfo(type: string) {
   const t = (type || '').toLowerCase();
   if (t === 'bug')
     return {
-      class: 'bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-600/20',
+      class: 'bg-rose-50 dark:bg-rose-900/30 text-rose-700 dark:text-rose-300 ring-1 ring-inset ring-rose-600/20 dark:ring-rose-500/30',
       icon: <Bug className="w-3 h-3" />,
     };
   if (t === 'feature')
     return {
-      class: 'bg-purple-50 text-purple-700 ring-1 ring-inset ring-purple-700/10',
+      class: 'bg-purple-50 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 ring-1 ring-inset ring-purple-700/10 dark:ring-purple-500/30',
       icon: <Box className="w-3 h-3" />,
     };
   if (t === 'epic')
     return {
-      class: 'bg-indigo-50 text-indigo-700 ring-1 ring-inset ring-indigo-700/10',
+      class: 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300 ring-1 ring-inset ring-indigo-700/10 dark:ring-indigo-500/30',
       icon: <Boxes className="w-3 h-3" />,
     };
   return {
-    class: 'bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-700/10',
+    class: 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 ring-1 ring-inset ring-blue-700/10 dark:ring-blue-500/30',
     icon: <ListCheck className="w-3 h-3" />,
   };
 }
@@ -229,16 +229,16 @@ function getTypeInfo(type: string) {
 function getPriorityStyle(priority: Priority) {
   switch (priority) {
     case 0:
-      return 'bg-red-100 text-red-800 border border-red-200';
+      return 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300 border border-red-200 dark:border-red-800';
     case 1:
-      return 'bg-orange-100 text-orange-800 border border-orange-200';
+      return 'bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-300 border border-orange-200 dark:border-orange-800';
     case 2:
-      return 'bg-yellow-100 text-yellow-800 border border-yellow-200';
+      return 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300 border border-yellow-200 dark:border-yellow-800';
     case 3:
-      return 'bg-green-100 text-green-800 border border-green-200';
+      return 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 border border-green-200 dark:border-green-800';
     case 4:
-      return 'bg-slate-100 text-slate-800 border border-slate-200';
+      return 'bg-slate-100 dark:bg-slate-700 text-slate-800 dark:text-slate-200 border border-slate-200 dark:border-slate-600';
     default:
-      return 'bg-slate-100 text-slate-800 border border-slate-200';
+      return 'bg-slate-100 dark:bg-slate-700 text-slate-800 dark:text-slate-200 border border-slate-200 dark:border-slate-600';
   }
 }

--- a/src/client/components/TableView.tsx
+++ b/src/client/components/TableView.tsx
@@ -18,12 +18,12 @@ function TableView({ issues }: TableViewProps) {
 
   return (
     <div className="space-y-4">
-      <div className="flex space-x-4 border-b border-slate-200">
+      <div className="flex space-x-4 border-b border-slate-200 dark:border-slate-700">
         <button
           className={`pb-2 px-1 text-sm font-medium transition-colors ${
             activeView === 'issues'
-              ? 'border-b-2 border-blue-500 text-blue-600'
-              : 'text-slate-500 hover:text-slate-700'
+              ? 'border-b-2 border-blue-500 text-blue-600 dark:text-blue-400'
+              : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
           }`}
           onClick={() => setActiveView('issues')}
         >
@@ -32,8 +32,8 @@ function TableView({ issues }: TableViewProps) {
         <button
           className={`pb-2 px-1 text-sm font-medium transition-colors ${
             activeView === 'epics'
-              ? 'border-b-2 border-blue-500 text-blue-600'
-              : 'text-slate-500 hover:text-slate-700'
+              ? 'border-b-2 border-blue-500 text-blue-600 dark:text-blue-400'
+              : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
           }`}
           onClick={() => setActiveView('epics')}
         >

--- a/src/client/components/ThresholdInput.tsx
+++ b/src/client/components/ThresholdInput.tsx
@@ -9,7 +9,7 @@ interface ThresholdInputProps {
 export function ThresholdInput({ label, value, unit, onValueChange, onUnitChange }: ThresholdInputProps) {
   return (
     <div>
-      <label htmlFor={label.toLowerCase().replace(/\s+/g, '-')} className="block text-xs font-medium text-slate-600 mb-1">
+      <label htmlFor={label.toLowerCase().replace(/\s+/g, '-')} className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
         {label}
       </label>
       <div className="flex gap-2">
@@ -20,12 +20,12 @@ export function ThresholdInput({ label, value, unit, onValueChange, onUnitChange
           step="0.5"
           value={value}
           onChange={(e) => onValueChange(parseFloat(e.target.value))}
-          className="w-full px-3 py-2 text-sm border border-slate-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          className="w-full px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
         />
         <select
           value={unit}
           onChange={(e) => onUnitChange(e.target.value as 'hours' | 'days')}
-          className="px-3 py-2 text-sm border border-slate-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          className="px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-md bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
         >
           <option value="hours">hours</option>
           <option value="days">days</option>

--- a/src/client/components/ThresholdPreview.tsx
+++ b/src/client/components/ThresholdPreview.tsx
@@ -22,31 +22,31 @@ export function ThresholdPreview({
   criticalHours,
 }: ThresholdPreviewProps) {
   return (
-    <div className="border-t border-slate-200 pt-4">
-      <h4 className="text-sm font-bold text-slate-700 mb-3">Preview</h4>
-      <p className="text-xs text-slate-500 mb-3">
+    <div className="border-t border-slate-200 dark:border-slate-700 pt-4">
+      <h4 className="text-sm font-bold text-slate-700 dark:text-slate-200 mb-3">Preview</h4>
+      <p className="text-xs text-slate-500 dark:text-slate-400 mb-3">
         Based on current configuration, these items would be flagged:
       </p>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div className={`p-3 rounded-lg border ${warningCount > 0 ? 'border-yellow-200 bg-yellow-50' : 'border-slate-200 bg-slate-50'}`}>
+        <div className={`p-3 rounded-lg border ${warningCount > 0 ? 'border-yellow-200 dark:border-yellow-800 bg-yellow-50 dark:bg-yellow-900/20' : 'border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700'}`}>
           <div className="flex items-center gap-2">
-            <AlertTriangle className={`w-4 h-4 ${warningCount > 0 ? 'text-yellow-600' : 'text-yellow-400'}`} />
+            <AlertTriangle className={`w-4 h-4 ${warningCount > 0 ? 'text-yellow-600 dark:text-yellow-400' : 'text-yellow-400 dark:text-yellow-600'}`} />
             <div>
-              <div className="text-sm font-medium text-slate-700">Warning Items</div>
-              <div className={`text-lg font-bold ${warningCount > 0 ? 'text-yellow-700' : 'text-slate-400'}`}>
+              <div className="text-sm font-medium text-slate-700 dark:text-slate-200">Warning Items</div>
+              <div className={`text-lg font-bold ${warningCount > 0 ? 'text-yellow-700 dark:text-yellow-400' : 'text-slate-400 dark:text-slate-500'}`}>
                 {warningCount}
               </div>
             </div>
           </div>
         </div>
 
-        <div className={`p-3 rounded-lg border ${criticalCount > 0 ? 'border-red-200 bg-red-50' : 'border-slate-200 bg-slate-50'}`}>
+        <div className={`p-3 rounded-lg border ${criticalCount > 0 ? 'border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20' : 'border-slate-200 dark:border-slate-600 bg-slate-50 dark:bg-slate-700'}`}>
           <div className="flex items-center gap-2">
-            <AlertOctagon className={`w-4 h-4 ${criticalCount > 0 ? 'text-red-600' : 'text-red-400'}`} />
+            <AlertOctagon className={`w-4 h-4 ${criticalCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-red-400 dark:text-red-600'}`} />
             <div>
-              <div className="text-sm font-medium text-slate-700">Critical Items</div>
-              <div className={`text-lg font-bold ${criticalCount > 0 ? 'text-red-700' : 'text-slate-400'}`}>
+              <div className="text-sm font-medium text-slate-700 dark:text-slate-200">Critical Items</div>
+              <div className={`text-lg font-bold ${criticalCount > 0 ? 'text-red-700 dark:text-red-400' : 'text-slate-400 dark:text-slate-500'}`}>
                 {criticalCount}
               </div>
             </div>
@@ -54,11 +54,11 @@ export function ThresholdPreview({
         </div>
       </div>
 
-      <div className="mt-4 p-3 bg-slate-50 rounded-lg text-xs">
+      <div className="mt-4 p-3 bg-slate-50 dark:bg-slate-700 rounded-lg text-xs">
         <div className="flex items-center gap-2 mb-1">
-          <span className="font-medium text-slate-600">Effective Thresholds:</span>
+          <span className="font-medium text-slate-600 dark:text-slate-300">Effective Thresholds:</span>
         </div>
-        <div className="text-slate-500">
+        <div className="text-slate-500 dark:text-slate-400">
           Warning: {warningThreshold} {warningUnit} ({warningHours} hours) •
           Critical: {criticalThreshold} {criticalUnit} ({criticalHours} hours)
         </div>

--- a/src/client/hooks/useTheme.ts
+++ b/src/client/hooks/useTheme.ts
@@ -1,0 +1,57 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const STORAGE_KEY = 'beads-theme';
+
+/**
+ * Hook to manage dark mode theme
+ * - Defaults to system preference
+ * - Allows manual override via toggle
+ * - Persists preference to localStorage
+ * - Listens for system preference changes (respects manual override)
+ */
+export function useTheme() {
+  const [isDark, setIsDark] = useState(() => {
+    // Check localStorage first
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === 'dark') return true;
+    if (stored === 'light') return false;
+
+    // Fall back to system preference
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  });
+
+  // Apply theme to document
+  useEffect(() => {
+    if (isDark) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [isDark]);
+
+  // Listen for system preference changes
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+    const handleChange = (e: MediaQueryListEvent | { matches: boolean }) => {
+      // Only update if user hasn't set a manual preference
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (!stored) {
+        setIsDark(e.matches);
+      }
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsDark((prev) => {
+      const newValue = !prev;
+      localStorage.setItem(STORAGE_KEY, newValue ? 'dark' : 'light');
+      return newValue;
+    });
+  }, []);
+
+  return { isDark, toggle };
+}

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -2,6 +2,21 @@ import '@testing-library/jest-dom';
 import { expect, afterEach, beforeEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 
+// Mock matchMedia for dark mode support
+const mockMatchMedia = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(), // deprecated
+  removeListener: vi.fn(), // deprecated
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+// Use vi.stubGlobal for proper jsdom compatibility
+vi.stubGlobal('matchMedia', mockMatchMedia);
+
 // Mock localStorage
 const localStorageMock = {
   store: {} as Record<string, string>,

--- a/tests/unit/App.test.tsx
+++ b/tests/unit/App.test.tsx
@@ -84,6 +84,14 @@ vi.mock('@/hooks/useMetrics', () => ({
   })),
 }));
 
+// Mock useTheme hook for dark mode
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: vi.fn(() => ({
+    isDark: false,
+    toggle: vi.fn(),
+  })),
+}));
+
 // Mock localStorage
 const localStorageMock = (() => {
   let store: Record<string, string> = {};
@@ -104,6 +112,21 @@ const localStorageMock = (() => {
 Object.defineProperty(window, 'localStorage', {
   value: localStorageMock,
   writable: true,
+});
+
+// Mock matchMedia for dark mode support
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
 });
 
 // Sample test data

--- a/tests/unit/useTheme.test.ts
+++ b/tests/unit/useTheme.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTheme } from '../../src/client/hooks/useTheme';
+
+describe('useTheme', () => {
+  let originalMatchMedia: typeof window.matchMedia;
+  let mockAddEventListener: ReturnType<typeof vi.fn>;
+  let mockRemoveEventListener: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Clear localStorage
+    localStorage.clear();
+
+    // Remove any existing dark class from document
+    document.documentElement.classList.remove('dark');
+
+    // Store original matchMedia
+    originalMatchMedia = window.matchMedia;
+
+    // Setup mock matchMedia
+    mockAddEventListener = vi.fn();
+    mockRemoveEventListener = vi.fn();
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  const createMockMatchMedia = (matches: boolean) => {
+    return vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(), // deprecated
+      removeListener: vi.fn(), // deprecated
+      addEventListener: mockAddEventListener,
+      removeEventListener: mockRemoveEventListener,
+      dispatchEvent: vi.fn(),
+    }));
+  };
+
+  describe('initial state', () => {
+    it('should default to light mode when no localStorage and system prefers light', () => {
+      window.matchMedia = createMockMatchMedia(false);
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.isDark).toBe(false);
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+
+    it('should default to dark mode when no localStorage and system prefers dark', () => {
+      window.matchMedia = createMockMatchMedia(true);
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.isDark).toBe(true);
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+
+    it('should use localStorage preference over system preference (dark)', () => {
+      window.matchMedia = createMockMatchMedia(false); // system prefers light
+      localStorage.setItem('beads-theme', 'dark');
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.isDark).toBe(true);
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+
+    it('should use localStorage preference over system preference (light)', () => {
+      window.matchMedia = createMockMatchMedia(true); // system prefers dark
+      localStorage.setItem('beads-theme', 'light');
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.isDark).toBe(false);
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+  });
+
+  describe('toggle', () => {
+    it('should toggle from light to dark', () => {
+      window.matchMedia = createMockMatchMedia(false);
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.isDark).toBe(false);
+
+      act(() => {
+        result.current.toggle();
+      });
+
+      expect(result.current.isDark).toBe(true);
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+
+    it('should toggle from dark to light', () => {
+      window.matchMedia = createMockMatchMedia(true);
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.isDark).toBe(true);
+
+      act(() => {
+        result.current.toggle();
+      });
+
+      expect(result.current.isDark).toBe(false);
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+
+    it('should persist toggle preference to localStorage', () => {
+      window.matchMedia = createMockMatchMedia(false);
+
+      const { result } = renderHook(() => useTheme());
+
+      act(() => {
+        result.current.toggle();
+      });
+
+      expect(localStorage.getItem('beads-theme')).toBe('dark');
+
+      act(() => {
+        result.current.toggle();
+      });
+
+      expect(localStorage.getItem('beads-theme')).toBe('light');
+    });
+  });
+
+  describe('system preference listener', () => {
+    it('should register listener for system preference changes', () => {
+      window.matchMedia = createMockMatchMedia(false);
+
+      renderHook(() => useTheme());
+
+      expect(mockAddEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+    });
+
+    it('should clean up listener on unmount', () => {
+      window.matchMedia = createMockMatchMedia(false);
+
+      const { unmount } = renderHook(() => useTheme());
+
+      unmount();
+
+      expect(mockRemoveEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+    });
+
+    it('should update theme when system preference changes and no manual override', () => {
+      let changeHandler: ((e: { matches: boolean }) => void) | null = null;
+
+      mockAddEventListener.mockImplementation((event: string, handler: (e: { matches: boolean }) => void) => {
+        if (event === 'change') {
+          changeHandler = handler;
+        }
+      });
+
+      window.matchMedia = createMockMatchMedia(false);
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.isDark).toBe(false);
+
+      // Simulate system preference change
+      act(() => {
+        if (changeHandler) {
+          changeHandler({ matches: true });
+        }
+      });
+
+      expect(result.current.isDark).toBe(true);
+    });
+
+    it('should NOT update theme when system preference changes if manual override exists', () => {
+      let changeHandler: ((e: { matches: boolean }) => void) | null = null;
+
+      mockAddEventListener.mockImplementation((event: string, handler: (e: { matches: boolean }) => void) => {
+        if (event === 'change') {
+          changeHandler = handler;
+        }
+      });
+
+      window.matchMedia = createMockMatchMedia(false);
+      localStorage.setItem('beads-theme', 'light'); // Manual override
+
+      const { result } = renderHook(() => useTheme());
+
+      expect(result.current.isDark).toBe(false);
+
+      // Simulate system preference change
+      act(() => {
+        if (changeHandler) {
+          changeHandler({ matches: true });
+        }
+      });
+
+      // Should NOT change because user has manual override
+      expect(result.current.isDark).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds comprehensive dark mode theming with system preference detection
- Toggle button in header allows manual override (persisted to localStorage)
- Defaults to OS preference via `prefers-color-scheme` media query

## Changes

- New `useTheme` hook for theme state management
- Tailwind configured with `darkMode: 'class'` strategy
- All 22 component files updated with `dark:` variants
- Full test coverage for theme hook (11 tests)

## Test plan

- [x] All 197 existing tests pass
- [x] Toggle switches between light/dark modes
- [x] Follows system preference on first load
- [x] Manual preference persists across page reloads
- [x] Responds to OS preference changes (when no manual override set)